### PR TITLE
Handling cases where when of the values is null or values have different types

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/JSONCompare.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONCompare.java
@@ -112,6 +112,31 @@ public class JSONCompare {
             else if (!expectedValue.equals(actualValue)) {
                 result.fail(fullKey, expectedValue, actualValue);
             }
+        } else {
+            if (isNull(expectedValue)) {
+                result.fail(fullKey + ": expected null, but got " + classToType(actualValue));
+            } else if (isNull(actualValue)) {
+                result.fail(fullKey + ": expected " + classToType(expectedValue) + ", but got null");
+            } else {
+                result.fail("Values of " + fullKey + " have different types: expected " + classToType(expectedValue)
+                        + ", but got " + classToType(actualValue));
+            }
+        }
+    }
+
+    private static boolean isNull(Object value) {
+        return value.getClass().getSimpleName().equals("Null");
+    }
+
+    private static String classToType(Object value) {
+        if (value instanceof JSONArray) {
+            return "an array";
+        } else if (value instanceof JSONObject) {
+            return "an object";
+        } else if (value instanceof String) {
+            return "a string";
+        } else {
+            return value.getClass().getName();
         }
     }
 

--- a/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
@@ -135,6 +135,23 @@ public class JSONAssertTest {
         testPass("{id:1,stuff:[[4,3],[3,2],[],[1,2]]}", "{id:1,stuff:[[1,2],[2,3],[],[3,4]]}", false);
     }
 
+    @Test
+    public void testNullProperty() throws JSONException {
+        testFail("{id:1,name:\"Joe\"}", "{id:1,name:null}", true);
+        testFail("{id:1,name:null}", "{id:1,name:\"Joe\"}", true);
+    }
+
+    @Test
+    public void testIncorrectTypes() throws JSONException {
+        testFail("{id:1,name:\"Joe\"}", "{id:1,name:[]}", true);
+        testFail("{id:1,name:[]}", "{id:1,name:\"Joe\"}", true);
+    }
+
+    @Test
+    public void testNullEquality() throws JSONException {
+        testPass("{id:1,name:null}", "{id:1,name:null}", true);
+    }
+
     private void testPass(String expected, String actual, boolean strict)
         throws JSONException
     {


### PR DESCRIPTION
Hi,

I am not sure if you will agree but I discovered cases when two different JSON strings are treated as equal, e.g.:
1) when one of the values is null
2) when values have different types, e.g. string and array

I have added few tests to illustrate this and proposition for changes to deal with such cases.
