### PR TITLE
Expose a list of field comparison failures, not just one

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/FieldComparisonFailure.java
+++ b/src/main/java/org/skyscreamer/jsonassert/FieldComparisonFailure.java
@@ -1,0 +1,28 @@
+package org.skyscreamer.jsonassert;
+
+/**
+ * Models a failure when comparing two fields.
+ */
+public class FieldComparisonFailure {
+    private final String _field;
+    private final Object _expected;
+    private final Object _actual;
+
+    public FieldComparisonFailure(String field, Object expected, Object actual) {
+        this._field = field;
+        this._expected = expected;
+        this._actual = actual;
+    }
+
+    public String getField() {
+        return _field;
+    }
+
+    public Object getExpected() {
+        return _expected;
+    }
+
+    public Object getActual() {
+        return _actual;
+    }
+}

--- a/src/main/java/org/skyscreamer/jsonassert/JSONCompareResult.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONCompareResult.java
@@ -1,5 +1,9 @@
 package org.skyscreamer.jsonassert;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Bean for holding results from JSONCompare.
  */
@@ -9,6 +13,7 @@ public class JSONCompareResult {
     private String _field;
     private Object _expected;
     private Object _actual;
+    private final List<FieldComparisonFailure> _fieldFailures = new ArrayList<FieldComparisonFailure>();
 
     /**
      * Default constructor.
@@ -47,11 +52,19 @@ public class JSONCompareResult {
     }
 
     /**
+     * Get the list of failures on field comparisons
+     */
+    public List<FieldComparisonFailure> getFieldFailures() {
+        return Collections.unmodifiableList(_fieldFailures);
+    }
+
+    /**
      * Actual field value
      * 
      * @return a {@code JSONObject}, {@code JSONArray} or other {@code Object}
      *         instance, or {@code null} if the comparison did not fail on a
      *         particular field
+     * @deprecated Superseded by {@link #getFieldFailures()}
      */
     public Object getActual() {
         return _actual;
@@ -63,16 +76,17 @@ public class JSONCompareResult {
      * @return a {@code JSONObject}, {@code JSONArray} or other {@code Object}
      *         instance, or {@code null} if the comparison did not fail on a
      *         particular field
+     * @deprecated Superseded by {@link #getFieldFailures()}
      */
     public Object getExpected() {
         return _expected;
     }
     
     /**
-     * Check if comparison failed on a particular field
+     * Check if comparison failed on any particular fields
      */
     public boolean isFailureOnField() {
-        return _field != null;
+        return !_fieldFailures.isEmpty();
     }
 
     /**
@@ -80,6 +94,7 @@ public class JSONCompareResult {
      * 
      * @return a {@code String} instance, or {@code null} if the comparison did
      *         not fail on a particular field
+     * @deprecated Superseded by {@link #getFieldFailures()}
      */
     public String getField() {
         return _field;
@@ -102,6 +117,7 @@ public class JSONCompareResult {
      * @param actual Actual result
      */
     protected void fail(String field, Object expected, Object actual) {
+        _fieldFailures.add(new FieldComparisonFailure(field, expected, actual));
         this._field = field;
         this._expected = expected;
         this._actual = actual;

--- a/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
@@ -1,5 +1,7 @@
 package org.skyscreamer.jsonassert;
 
+import java.util.Arrays;
+
 import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -147,6 +149,11 @@ public class JSONAssertTest {
         Assert.assertEquals("Pat", result.getExpected());
         Assert.assertEquals("Sue", result.getActual());
         Assert.assertEquals("name", result.getField());
+
+        FieldComparisonFailure comparisonFailure = result.getFieldFailures().iterator().next();
+        Assert.assertEquals("Pat", comparisonFailure.getExpected());
+        Assert.assertEquals("Sue", comparisonFailure.getActual());
+        Assert.assertEquals("name", comparisonFailure.getField());
     }
 
     @Test


### PR DESCRIPTION
I've realised that I kinda screwed up with [pull request #7](https://github.com/skyscreamer/JSONassert/pull/7).  Instead of exposing the most recent field comparison failure, I should have exposed a list of them.

I've deprecated some methods on `JSONCompareResult`, but I could remove them altogether...

For some background, I'm hoping to build a better object model of comparison failures instead of relying on JSONCompareResult's String formatting.  That way, I can improve diagnostic output for my Hamcrest matchers.
