### PR TITLE
Implemented #21: Add possibility to override/extend comparison behavior

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/JSONAssert.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONAssert.java
@@ -3,6 +3,7 @@ package org.skyscreamer.jsonassert;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.skyscreamer.jsonassert.comparator.JSONComparator;
 
 /**
  * <p>A set of assertion methods useful for writing tests methods that return JSON.</p>
@@ -92,6 +93,24 @@ public class JSONAssert {
             throws JSONException
     {
         JSONCompareResult result = JSONCompare.compareJSON(expectedStr, actualStr, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
+        if (result.failed()) {
+            throw new AssertionError(result.getMessage());
+        }
+    }
+
+    /**
+     * Asserts that the json string provided matches the expected string.  If it isn't it throws an
+     * {@link AssertionError}.
+     *
+     * @param expectedStr Expected JSON string
+     * @param actualStr String to compare
+     * @param comparator Comparator
+     * @throws JSONException
+     */
+    public static void assertEquals(String expectedStr, String actualStr, JSONComparator comparator)
+            throws JSONException
+    {
+        JSONCompareResult result = JSONCompare.compareJSON(expectedStr, actualStr, comparator);
         if (result.failed()) {
             throw new AssertionError(result.getMessage());
         }

--- a/src/main/java/org/skyscreamer/jsonassert/JSONCompare.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONCompare.java
@@ -1,38 +1,42 @@
 package org.skyscreamer.jsonassert;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.util.*;
+import org.skyscreamer.jsonassert.comparator.DefaultComparator;
+import org.skyscreamer.jsonassert.comparator.JSONComparator;
 
 /**
- * Provides the logic to compare two JSON entities.  This is the backend to {@link JSONAssert}, but it can
+ * Provides API to compare two JSON entities.  This is the backend to {@link JSONAssert}, but it can
  * be programmed against directly to access the functionality.  (eg, to make something that works with a
  * non-JUnit test framework)
  */
-public class JSONCompare {
-    private JSONCompare() {}
+public final class JSONCompare {
+    private JSONCompare() {
+    }
+
+    private static JSONComparator getComparatorForMode(JSONCompareMode mode) {
+        return new DefaultComparator(mode);
+    }
 
     /**
-     * Compares JSON string provided to the expected JSON string, and returns the results of the comparison.
-     *
+     * Compares JSON string provided to the expected JSON string using provided comparator, and returns the results of the comparison.
      * @param expectedStr Expected JSON string
      * @param actualStr JSON string to compare
-     * @param mode Defines comparison behavior
+     * @param comparator Comparator to use
+     * @return result of the comparison
      * @throws JSONException
+     * @throws IllegalArgumentException when type of expectedStr doesn't match the type of actualStr
      */
-    public static JSONCompareResult compareJSON(String expectedStr, String actualStr, JSONCompareMode mode)
-            throws JSONException
-    {
+    public static JSONCompareResult compareJSON(String expectedStr, String actualStr, JSONComparator comparator)
+            throws JSONException {
         Object expected = JSONParser.parseJSON(expectedStr);
         Object actual = JSONParser.parseJSON(actualStr);
         if ((expected instanceof JSONObject) && (actual instanceof JSONObject)) {
-            return compareJSON((JSONObject) expected, (JSONObject) actual, mode);
+            return compareJSON((JSONObject) expected, (JSONObject) actual, comparator);
         }
         else if ((expected instanceof JSONArray) && (actual instanceof JSONArray)) {
-            return compareJSON((JSONArray)expected, (JSONArray)actual, mode);
+            return compareJSON((JSONArray)expected, (JSONArray)actual, comparator);
         }
         else if (expected instanceof JSONObject) {
             return new JSONCompareResult().fail("", expected, actual);
@@ -43,294 +47,67 @@ public class JSONCompare {
     }
 
     /**
+     * Compares JSON object provided to the expected JSON object using provided comparator, and returns the results of the comparison.
+     * @param expected expected json object
+     * @param actual actual json object
+     * @param comparator comparator to use
+     * @return result of the comparison
+     * @throws JSONException
+     */
+    public static JSONCompareResult compareJSON(JSONObject expected, JSONObject actual, JSONComparator comparator) throws JSONException {
+        return comparator.compareJSON(expected, actual);
+    }
+
+    /**
+     * Compares JSON object provided to the expected JSON object using provided comparator, and returns the results of the comparison.
+     * @param expected expected json array
+     * @param actual actual json array
+     * @param comparator comparator to use
+     * @return result of the comparison
+     * @throws JSONException
+     */
+    public static JSONCompareResult compareJSON(JSONArray expected, JSONArray actual, JSONComparator comparator) throws JSONException {
+        return comparator.compareJSON(expected, actual);
+    }
+
+    /**
+     * Compares JSON string provided to the expected JSON string, and returns the results of the comparison.
+     *
+     * @param expectedStr Expected JSON string
+     * @param actualStr   JSON string to compare
+     * @param mode        Defines comparison behavior
+     * @throws JSONException
+     */
+    public static JSONCompareResult compareJSON(String expectedStr, String actualStr, JSONCompareMode mode)
+            throws JSONException {
+        return compareJSON(expectedStr, actualStr, getComparatorForMode(mode));
+    }
+
+    /**
      * Compares JSONObject provided to the expected JSONObject, and returns the results of the comparison.
      *
      * @param expected Expected JSONObject
-     * @param actual JSONObject to compare
-     * @param mode Defines comparison behavior
+     * @param actual   JSONObject to compare
+     * @param mode     Defines comparison behavior
      * @throws JSONException
      */
     public static JSONCompareResult compareJSON(JSONObject expected, JSONObject actual, JSONCompareMode mode)
-            throws JSONException
-    {
-        JSONCompareResult result = new JSONCompareResult();
-        compareJSON("", expected, actual, mode, result);
-        return result;
+            throws JSONException {
+        return compareJSON(expected, actual, getComparatorForMode(mode));
     }
+
 
     /**
      * Compares JSONArray provided to the expected JSONArray, and returns the results of the comparison.
      *
      * @param expected Expected JSONArray
-     * @param actual JSONArray to compare
-     * @param mode Defines comparison behavior
+     * @param actual   JSONArray to compare
+     * @param mode     Defines comparison behavior
      * @throws JSONException
      */
     public static JSONCompareResult compareJSON(JSONArray expected, JSONArray actual, JSONCompareMode mode)
-            throws JSONException
-    {
-        JSONCompareResult result = new JSONCompareResult();
-        compareJSONArray("", expected, actual, mode, result);
-        return result;
+            throws JSONException {
+        return compareJSON(expected, actual, getComparatorForMode(mode));
     }
 
-    private static void compareJSON(String prefix, JSONObject expected, JSONObject actual, JSONCompareMode mode, JSONCompareResult result)
-            throws JSONException
-    {
-        // Check that actual contains all the expected values
-        Set<String> expectedKeys = getKeys(expected);
-        for(String key : expectedKeys) {
-            Object expectedValue = expected.get(key);
-            if (actual.has(key)) {
-                Object actualValue = actual.get(key);
-                compareValues(qualify(prefix, key), expectedValue, actualValue, mode, result);
-            }
-            else {
-                result.missing(prefix, key);
-            }
-        }
-
-        // If non-extensible, check for vice-versa
-        if (!mode.isExtensible()) {
-            Set<String> actualKeys = getKeys(actual);
-            for(String key : actualKeys) {
-                if (!expected.has(key)) {
-                    result.unexpected(prefix, key);
-                }
-            }
-        }
-    }
-
-    private static String qualify(String prefix, String key) {
-        return "".equals(prefix) ? key : prefix + "." + key;
-    }
-
-    private static void compareValues(String fullKey, Object expectedValue, Object actualValue, JSONCompareMode mode, JSONCompareResult result) throws JSONException 
-    {
-        if (expectedValue.getClass().isAssignableFrom(actualValue.getClass())) {
-            if (expectedValue instanceof JSONArray) {
-                compareJSONArray(fullKey , (JSONArray)expectedValue, (JSONArray)actualValue, mode, result);
-            }
-            else if (expectedValue instanceof JSONObject) {
-                compareJSON(fullKey, (JSONObject) expectedValue, (JSONObject) actualValue, mode, result);
-            }
-            else if (!expectedValue.equals(actualValue)) {
-                result.fail(fullKey, expectedValue, actualValue);
-            }
-        } else {
-            result.fail(fullKey, expectedValue, actualValue);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void compareJSONArray(String key, JSONArray expected, JSONArray actual, JSONCompareMode mode,
-                                         JSONCompareResult result) throws JSONException
-    {
-        if (expected.length() != actual.length()) {
-            result.fail(key + "[]: Expected " + expected.length() + " values but got " + actual.length());
-            return;
-        }
-        else if (expected.length() == 0) {
-            return; // Nothing to compare
-        }
-
-        if (mode.hasStrictOrder()) {
-            for(int i = 0 ; i < expected.length() ; ++i) {
-                Object expectedValue = expected.get(i);
-                Object actualValue = actual.get(i);
-                compareValues(key + "[" + i + "]", expectedValue, actualValue, mode, result);
-            }
-        }
-        else if (allSimpleValues(expected)) {
-            Map<Object, Integer> expectedCount = CollectionUtils.getCardinalityMap(jsonArrayToList(expected));
-            Map<Object, Integer> actualCount = CollectionUtils.getCardinalityMap(jsonArrayToList(actual));
-            for(Object o : expectedCount.keySet()) {
-                if (!actualCount.containsKey(o)) {
-                    result.missing(key + "[]", o);
-                }
-                else if (!actualCount.get(o).equals(expectedCount.get(o))) {
-                    result.fail(key + "[]: Expected " + expectedCount.get(o) + " occurrence(s) of " + o
-                            + " but got " + actualCount.get(o) + " occurrence(s)");
-                }
-            }
-            for(Object o : actualCount.keySet()) {
-                if (!expectedCount.containsKey(o)) {
-                    result.unexpected(key + "[]", o);
-                }
-            }
-        }
-        else if (allJSONObjects(expected)) {
-            String uniqueKey = findUniqueKey(expected);
-            if (uniqueKey == null || !isUsableAsUniqueKey(uniqueKey, actual)) {
-                // An expensive last resort
-                recursivelyCompareJSONArray(key, expected, actual, mode, result);
-                return;
-            }
-            Map<Object, JSONObject> expectedValueMap = arrayOfJsonObjectToMap(expected, uniqueKey);
-            Map<Object, JSONObject> actualValueMap = arrayOfJsonObjectToMap(actual, uniqueKey);
-            for(Object id : expectedValueMap.keySet()) {
-                if (!actualValueMap.containsKey(id)) {
-                    result.missing(formatUniqueKey(key, uniqueKey, id), expectedValueMap.get(id));
-                    continue;
-                }
-                JSONObject expectedValue = expectedValueMap.get(id);
-                JSONObject actualValue = actualValueMap.get(id);
-                compareValues(formatUniqueKey(key, uniqueKey, id), expectedValue, actualValue, mode, result);
-            }
-            for(Object id : actualValueMap.keySet()) {
-                if (!expectedValueMap.containsKey(id)) {
-                    result.unexpected(formatUniqueKey(key, uniqueKey, id), actualValueMap.get(id));
-                }
-            }
-        }
-        else if (allJSONArrays(expected)) {
-            // An expensive last resort
-            recursivelyCompareJSONArray(key, expected, actual, mode, result);
-            return;
-        }
-        else {
-            // An expensive last resort
-            recursivelyCompareJSONArray(key, expected, actual, mode, result);
-            return;
-        }
-    }
-
-    private static String formatUniqueKey(String key, String uniqueKey, Object value) {
-        return key + "[" + uniqueKey + "=" + value + "]";
-    }
-
-    // This is expensive (O(n^2) -- yuck), but may be the only resort for some cases with loose array ordering, and no
-    // easy way to uniquely identify each element.
-    private static void recursivelyCompareJSONArray(String key, JSONArray expected, JSONArray actual,
-                                                    JSONCompareMode mode, JSONCompareResult result) throws JSONException {
-        Set<Integer> matched = new HashSet<Integer>();
-        for(int i = 0 ; i < expected.length() ; ++i) {
-            Object expectedElement = expected.get(i);
-            boolean matchFound = false;
-            for(int j = 0 ; j < actual.length() ; ++j) {
-                Object actualElement = actual.get(j);
-				if (matched.contains(j) || !actualElement.getClass().equals(expectedElement.getClass())) {
-                    continue;
-                }
-                if (expectedElement instanceof JSONObject) {
-                    if (compareJSON((JSONObject)expectedElement, (JSONObject)actualElement, mode).passed()) {
-                        matched.add(j);
-                        matchFound = true;
-                        break;
-                    }
-                }
-                else if (expectedElement instanceof JSONArray) {
-                    if (compareJSON((JSONArray)expectedElement, (JSONArray)actualElement, mode).passed()) {
-                        matched.add(j);
-                        matchFound = true;
-                        break;
-                    }
-                }
-                else if (expectedElement.equals(actualElement)) {
-                    matched.add(j);
-                    matchFound = true;
-                    break;
-                }
-            }
-            if (!matchFound) {
-                result.fail(key + "[" + i + "] Could not find match for element " + expectedElement);
-                return;
-            }
-        }
-    }
-
-    private static Map<Object,JSONObject> arrayOfJsonObjectToMap(JSONArray array, String uniqueKey) throws JSONException {
-        Map<Object, JSONObject> valueMap = new HashMap<Object, JSONObject>();
-        for(int i = 0 ; i < array.length() ; ++i) {
-            JSONObject jsonObject = (JSONObject)array.get(i);
-            Object id = jsonObject.get(uniqueKey);
-            valueMap.put(id, jsonObject);
-        }
-        return valueMap;
-    }
-
-    private static String findUniqueKey(JSONArray expected) throws JSONException {
-        // Find a unique key for the object (id, name, whatever)
-        JSONObject o = (JSONObject)expected.get(0); // There's at least one at this point
-        for(String candidate : getKeys(o)) {
-            if (isUsableAsUniqueKey(candidate, expected)) return candidate;
-        }
-        // No usable unique key :-(
-        return null;
-    }
-
-    /**
-     * {@code candidate} is usable as a unique key if every element in the
-     * {@code array} is a JSONObject having that key, and no two values are the same.
-     */
-    private static boolean isUsableAsUniqueKey(String candidate, JSONArray array) throws JSONException {
-        Set<Object> seenValues = new HashSet<Object>();
-        for (int i = 0 ; i < array.length() ; i++) {
-            Object item = array.get(i);
-            if (item instanceof JSONObject) {
-                JSONObject o = (JSONObject) item;
-                if (o.has(candidate)) {
-                    Object value = o.get(candidate);
-                    if (isSimpleValue(value) && !seenValues.contains(value)) {
-                        seenValues.add(value);
-                    } else {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static List<Object> jsonArrayToList(JSONArray expected) throws JSONException {
-        List<Object> jsonObjects = new ArrayList<Object>(expected.length());
-        for(int i = 0 ; i < expected.length() ; ++i) {
-            jsonObjects.add(expected.get(i));
-        }
-        return jsonObjects;
-    }
-
-    private static boolean allSimpleValues(JSONArray array) throws JSONException {
-        for(int i = 0 ; i < array.length() ; ++i) {
-            if (!isSimpleValue(array.get(i))) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static boolean isSimpleValue(Object o) {
-        return !(o instanceof JSONObject) && !(o instanceof JSONArray);
-    }
-
-    private static boolean allJSONObjects(JSONArray array) throws JSONException {
-        for(int i = 0 ; i < array.length() ; ++i) {
-            if (!(array.get(i) instanceof JSONObject)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static boolean allJSONArrays(JSONArray array) throws JSONException {
-        for(int i = 0 ; i < array.length() ; ++i) {
-            if (!(array.get(i) instanceof JSONArray)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static Set<String> getKeys(JSONObject jsonObject) {
-        Set<String> keys = new TreeSet<String>();
-        Iterator<?> iter = jsonObject.keys();
-        while(iter.hasNext()) {
-            keys.add((String)iter.next());
-        }
-        return keys;
-    }
 }

--- a/src/main/java/org/skyscreamer/jsonassert/JSONCompareResult.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONCompareResult.java
@@ -12,7 +12,7 @@ import org.json.JSONObject;
  */
 public class JSONCompareResult {
     private boolean _success;
-    private String _message;
+    private StringBuilder _message;
     private String _field;
     private Object _expected;
     private Object _actual;
@@ -27,7 +27,7 @@ public class JSONCompareResult {
 
     private JSONCompareResult(boolean success, String message) {
         _success = success;
-        _message = message == null ? "" : message;
+        _message = new StringBuilder(message == null ? "" : message);
     }
 
     /**
@@ -51,7 +51,7 @@ public class JSONCompareResult {
      * @return String explaining why if the comparison failed
      */
     public String getMessage() {
-        return _message;
+        return _message.toString();
     }
 
     /**
@@ -103,13 +103,12 @@ public class JSONCompareResult {
         return _field;
     }
     
-    protected void fail(String message) {
+    public void fail(String message) {
         _success = false;
         if (_message.length() == 0) {
-            _message = message;
-        }
-        else {
-            _message += " ; " + message;
+            _message.append(message);
+        } else {
+            _message.append(" ; ").append(message);
         }
     }
 
@@ -119,7 +118,7 @@ public class JSONCompareResult {
      * @param expected Expected result
      * @param actual Actual result
      */
-    protected JSONCompareResult fail(String field, Object expected, Object actual) {
+    public JSONCompareResult fail(String field, Object expected, Object actual) {
         _fieldFailures.add(new FieldComparisonFailure(field, expected, actual));
         this._field = field;
         this._expected = expected;
@@ -129,14 +128,12 @@ public class JSONCompareResult {
     }
 
     private String formatFailureMessage(String field, Object expected, Object actual) {
-        StringBuffer message= new StringBuffer();
-        message.append(field);
-        message.append("\nExpected: ");
-        message.append(describe(expected));
-        message.append("\n     got: ");
-        message.append(describe(actual));
-        message.append("\n");
-        return message.toString();
+        return field
+                + "\nExpected: "
+                + describe(expected)
+                + "\n     got: "
+                + describe(actual)
+                + "\n";
     }
 
     public JSONCompareResult missing(String field, Object expected) {
@@ -145,12 +142,10 @@ public class JSONCompareResult {
     }
 
     private String formatMissing(String field, Object expected) {
-        StringBuffer message= new StringBuffer();
-        message.append(field);
-        message.append("\nExpected: ");
-        message.append(describe(expected));
-        message.append("\n     but none found\n");
-        return message.toString();
+        return field
+                + "\nExpected: "
+                + describe(expected)
+                + "\n     but none found\n";
     }
 
     public JSONCompareResult unexpected(String field, Object value) {
@@ -159,12 +154,10 @@ public class JSONCompareResult {
     }
 
     private String formatUnexpected(String field, Object value) {
-        StringBuffer message= new StringBuffer();
-        message.append(field);
-        message.append("\nUnexpected: ");
-        message.append(describe(value));
-        message.append("\n");
-        return message.toString();
+        return field
+                + "\nUnexpected: "
+                + describe(value)
+                + "\n";
     }
 
     private static String describe(Object value) {
@@ -179,6 +172,6 @@ public class JSONCompareResult {
 
     @Override
     public String toString() {
-        return _message;
+        return _message.toString();
     }
 }

--- a/src/main/java/org/skyscreamer/jsonassert/JSONParser.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONParser.java
@@ -15,7 +15,7 @@ public class JSONParser {
      * depending on whether the string represents an object or an array.
      *
      * @param s Raw JSON string to be parsed
-     * @return
+     * @return JSONObject or JSONArray
      * @throws JSONException
      */
     public static Object parseJSON(String s) throws JSONException {

--- a/src/main/java/org/skyscreamer/jsonassert/comparator/AbstractComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/AbstractComparator.java
@@ -1,0 +1,163 @@
+package org.skyscreamer.jsonassert.comparator;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.skyscreamer.jsonassert.JSONCompareResult;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.skyscreamer.jsonassert.comparator.JSONCompareUtil.*;
+
+/**
+ * This class provides a skeletal implementation of the {@link JSONComparator}
+ * interface, to minimize the effort required to implement this interface. <p/>
+ */
+public abstract class AbstractComparator implements JSONComparator {
+
+    /**
+     * Compares JSONObject provided to the expected JSONObject, and returns the results of the comparison.
+     *
+     * @param expected Expected JSONObject
+     * @param actual   JSONObject to compare
+     * @throws JSONException
+     */
+    @Override
+    public final JSONCompareResult compareJSON(JSONObject expected, JSONObject actual) throws JSONException {
+        JSONCompareResult result = new JSONCompareResult();
+        compareJSON("", expected, actual, result);
+        return result;
+    }
+
+    /**
+     * Compares JSONArray provided to the expected JSONArray, and returns the results of the comparison.
+     *
+     * @param expected Expected JSONArray
+     * @param actual   JSONArray to compare
+     * @throws JSONException
+     */
+    @Override
+    public final JSONCompareResult compareJSON(JSONArray expected, JSONArray actual) throws JSONException {
+        JSONCompareResult result = new JSONCompareResult();
+        compareJSONArray("", expected, actual, result);
+        return result;
+    }
+
+    protected void checkJsonObjectKeysActualInExpected(String prefix, JSONObject expected, JSONObject actual, JSONCompareResult result) {
+        Set<String> actualKeys = getKeys(actual);
+        for (String key : actualKeys) {
+            if (!expected.has(key)) {
+                result.unexpected(prefix, key);
+            }
+        }
+    }
+
+    protected void checkJsonObjectKeysExpectedInActual(String prefix, JSONObject expected, JSONObject actual, JSONCompareResult result) throws JSONException {
+        Set<String> expectedKeys = getKeys(expected);
+        for (String key : expectedKeys) {
+            Object expectedValue = expected.get(key);
+            if (actual.has(key)) {
+                Object actualValue = actual.get(key);
+                compareValues(qualify(prefix, key), expectedValue, actualValue, result);
+            } else {
+                result.missing(prefix, key);
+            }
+        }
+    }
+
+    protected void compareJSONArrayOfJsonObjects(String key, JSONArray expected, JSONArray actual, JSONCompareResult result) throws JSONException {
+        String uniqueKey = findUniqueKey(expected);
+        if (uniqueKey == null || !isUsableAsUniqueKey(uniqueKey, actual)) {
+            // An expensive last resort
+            recursivelyCompareJSONArray(key, expected, actual, result);
+            return;
+        }
+        Map<Object, JSONObject> expectedValueMap = arrayOfJsonObjectToMap(expected, uniqueKey);
+        Map<Object, JSONObject> actualValueMap = arrayOfJsonObjectToMap(actual, uniqueKey);
+        for (Object id : expectedValueMap.keySet()) {
+            if (!actualValueMap.containsKey(id)) {
+                result.missing(formatUniqueKey(key, uniqueKey, id), expectedValueMap.get(id));
+                continue;
+            }
+            JSONObject expectedValue = expectedValueMap.get(id);
+            JSONObject actualValue = actualValueMap.get(id);
+            compareValues(formatUniqueKey(key, uniqueKey, id), expectedValue, actualValue, result);
+        }
+        for (Object id : actualValueMap.keySet()) {
+            if (!expectedValueMap.containsKey(id)) {
+                result.unexpected(formatUniqueKey(key, uniqueKey, id), actualValueMap.get(id));
+            }
+        }
+    }
+
+    protected void compareJSONArrayOfSimpleValues(String key, JSONArray expected, JSONArray actual, JSONCompareResult result) throws JSONException {
+        @SuppressWarnings("unchecked")
+        Map<Object, Integer> expectedCount = CollectionUtils.getCardinalityMap(jsonArrayToList(expected));
+        @SuppressWarnings("unchecked")
+        Map<Object, Integer> actualCount = CollectionUtils.getCardinalityMap(jsonArrayToList(actual));
+        for (Object o : expectedCount.keySet()) {
+            if (!actualCount.containsKey(o)) {
+                result.missing(key + "[]", o);
+            } else if (!actualCount.get(o).equals(expectedCount.get(o))) {
+                result.fail(key + "[]: Expected " + expectedCount.get(o) + " occurrence(s) of " + o
+                        + " but got " + actualCount.get(o) + " occurrence(s)");
+            }
+        }
+        for (Object o : actualCount.keySet()) {
+            if (!expectedCount.containsKey(o)) {
+                result.unexpected(key + "[]", o);
+            }
+        }
+    }
+
+    protected void compareJSONArrayWithStrictOrder(String key, JSONArray expected, JSONArray actual, JSONCompareResult result) throws JSONException {
+        for (int i = 0; i < expected.length(); ++i) {
+            Object expectedValue = expected.get(i);
+            Object actualValue = actual.get(i);
+            compareValues(key + "[" + i + "]", expectedValue, actualValue, result);
+        }
+    }
+
+    // This is expensive (O(n^2) -- yuck), but may be the only resort for some cases with loose array ordering, and no
+    // easy way to uniquely identify each element.
+    // This is expensive (O(n^2) -- yuck), but may be the only resort for some cases with loose array ordering, and no
+    // easy way to uniquely identify each element.
+    protected void recursivelyCompareJSONArray(String key, JSONArray expected, JSONArray actual,
+                                               JSONCompareResult result) throws JSONException {
+        Set<Integer> matched = new HashSet<Integer>();
+        for (int i = 0; i < expected.length(); ++i) {
+            Object expectedElement = expected.get(i);
+            boolean matchFound = false;
+            for (int j = 0; j < actual.length(); ++j) {
+                Object actualElement = actual.get(j);
+                if (matched.contains(j) || !actualElement.getClass().equals(expectedElement.getClass())) {
+                    continue;
+                }
+                if (expectedElement instanceof JSONObject) {
+                    if (compareJSON((JSONObject) expectedElement, (JSONObject) actualElement).passed()) {
+                        matched.add(j);
+                        matchFound = true;
+                        break;
+                    }
+                } else if (expectedElement instanceof JSONArray) {
+                    if (compareJSON((JSONArray) expectedElement, (JSONArray) actualElement).passed()) {
+                        matched.add(j);
+                        matchFound = true;
+                        break;
+                    }
+                } else if (expectedElement.equals(actualElement)) {
+                    matched.add(j);
+                    matchFound = true;
+                    break;
+                }
+            }
+            if (!matchFound) {
+                result.fail(key + "[" + i + "] Could not find match for element " + expectedElement);
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/org/skyscreamer/jsonassert/comparator/DefaultComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/DefaultComparator.java
@@ -1,0 +1,70 @@
+package org.skyscreamer.jsonassert.comparator;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.JSONCompareResult;
+
+import static org.skyscreamer.jsonassert.comparator.JSONCompareUtil.allJSONObjects;
+import static org.skyscreamer.jsonassert.comparator.JSONCompareUtil.allSimpleValues;
+
+/**
+ * This class is the default json comparator implementation. <p/>
+ * Comparison is performed according to  {@link JSONCompareMode} that is passed as constructor's argument.
+ */
+public class DefaultComparator extends AbstractComparator {
+
+    JSONCompareMode mode;
+
+    public DefaultComparator(JSONCompareMode mode) {
+        this.mode = mode;
+    }
+
+    @Override
+    public void compareJSON(String prefix, JSONObject expected, JSONObject actual, JSONCompareResult result) throws JSONException {
+        // Check that actual contains all the expected values
+        checkJsonObjectKeysExpectedInActual(prefix, expected, actual, result);
+
+        // If strict, check for vice-versa
+        if (!mode.isExtensible()) {
+            checkJsonObjectKeysActualInExpected(prefix, expected, actual, result);
+        }
+    }
+
+    @Override
+    public void compareValues(String prefix, Object expectedValue, Object actualValue, JSONCompareResult result) throws JSONException {
+        if (expectedValue.getClass().isAssignableFrom(actualValue.getClass())) {
+            if (expectedValue instanceof JSONArray) {
+                compareJSONArray(prefix, (JSONArray) expectedValue, (JSONArray) actualValue, result);
+            } else if (expectedValue instanceof JSONObject) {
+                compareJSON(prefix, (JSONObject) expectedValue, (JSONObject) actualValue, result);
+            } else if (!expectedValue.equals(actualValue)) {
+                result.fail(prefix, expectedValue, actualValue);
+            }
+        } else {
+            result.fail(prefix, expectedValue, actualValue);
+        }
+    }
+
+    @Override
+    public void compareJSONArray(String prefix, JSONArray expected, JSONArray actual, JSONCompareResult result) throws JSONException {
+        if (expected.length() != actual.length()) {
+            result.fail(prefix + "[]: Expected " + expected.length() + " values but got " + actual.length());
+            return;
+        } else if (expected.length() == 0) {
+            return; // Nothing to compare
+        }
+
+        if (mode.hasStrictOrder()) {
+            compareJSONArrayWithStrictOrder(prefix, expected, actual, result);
+        } else if (allSimpleValues(expected)) {
+            compareJSONArrayOfSimpleValues(prefix, expected, actual, result);
+        } else if (allJSONObjects(expected)) {
+            compareJSONArrayOfJsonObjects(prefix, expected, actual, result);
+        } else {
+            // An expensive last resort
+            recursivelyCompareJSONArray(prefix, expected, actual, result);
+        }
+    }
+}

--- a/src/main/java/org/skyscreamer/jsonassert/comparator/JSONComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/JSONComparator.java
@@ -1,0 +1,25 @@
+package org.skyscreamer.jsonassert.comparator;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.skyscreamer.jsonassert.JSONCompareResult;
+
+/**
+ * Interface for comparison handler.
+ *
+ * @author <a href="mailto:aiveeen@gmail.com">Ivan Zaytsev</a>
+ *         2013-01-04
+ */
+public interface JSONComparator {
+
+    JSONCompareResult compareJSON(JSONObject expected, JSONObject actual) throws JSONException;
+
+    JSONCompareResult compareJSON(JSONArray expected, JSONArray actual) throws JSONException;
+
+    void compareJSON(String prefix, JSONObject expected, JSONObject actual, JSONCompareResult result) throws JSONException;
+
+    void compareValues(String prefix, Object expectedValue, Object actualValue, JSONCompareResult result) throws JSONException;
+
+    void compareJSONArray(String prefix, JSONArray expected, JSONArray actual, JSONCompareResult result) throws JSONException;
+}

--- a/src/main/java/org/skyscreamer/jsonassert/comparator/JSONCompareUtil.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/JSONCompareUtil.java
@@ -1,0 +1,120 @@
+package org.skyscreamer.jsonassert.comparator;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.*;
+
+/**
+ * Utility class that contains Json manipulation methods
+ */
+public final class JSONCompareUtil {
+    private JSONCompareUtil() {}
+
+     public static Map<Object,JSONObject> arrayOfJsonObjectToMap(JSONArray array, String uniqueKey) throws JSONException {
+        Map<Object, JSONObject> valueMap = new HashMap<Object, JSONObject>();
+        for(int i = 0 ; i < array.length() ; ++i) {
+            JSONObject jsonObject = (JSONObject)array.get(i);
+            Object id = jsonObject.get(uniqueKey);
+            valueMap.put(id, jsonObject);
+        }
+        return valueMap;
+    }
+
+
+    public static String findUniqueKey(JSONArray expected) throws JSONException {
+        // Find a unique key for the object (id, name, whatever)
+        JSONObject o = (JSONObject)expected.get(0); // There's at least one at this point
+        for(String candidate : getKeys(o)) {
+            if (isUsableAsUniqueKey(candidate, expected)) return candidate;
+        }
+        // No usable unique key :-(
+        return null;
+    }
+
+    /**
+     * {@code candidate} is usable as a unique key if every element in the
+     * {@code array} is a JSONObject having that key, and no two values are the same.
+     */
+    public static boolean isUsableAsUniqueKey(String candidate, JSONArray array) throws JSONException {
+        Set<Object> seenValues = new HashSet<Object>();
+        for (int i = 0 ; i < array.length() ; i++) {
+            Object item = array.get(i);
+            if (item instanceof JSONObject) {
+                JSONObject o = (JSONObject) item;
+                if (o.has(candidate)) {
+                    Object value = o.get(candidate);
+                    if (isSimpleValue(value) && !seenValues.contains(value)) {
+                        seenValues.add(value);
+                    } else {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static List<Object> jsonArrayToList(JSONArray expected) throws JSONException {
+        List<Object> jsonObjects = new ArrayList<Object>(expected.length());
+        for(int i = 0 ; i < expected.length() ; ++i) {
+            jsonObjects.add(expected.get(i));
+        }
+        return jsonObjects;
+    }
+
+    public static boolean allSimpleValues(JSONArray array) throws JSONException {
+        for(int i = 0 ; i < array.length() ; ++i) {
+            if (!isSimpleValue(array.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean isSimpleValue(Object o) {
+        return !(o instanceof JSONObject) && !(o instanceof JSONArray);
+    }
+
+    public static boolean allJSONObjects(JSONArray array) throws JSONException {
+        for(int i = 0 ; i < array.length() ; ++i) {
+            if (!(array.get(i) instanceof JSONObject)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean allJSONArrays(JSONArray array) throws JSONException {
+        for(int i = 0 ; i < array.length() ; ++i) {
+            if (!(array.get(i) instanceof JSONArray)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static Set<String> getKeys(JSONObject jsonObject) {
+        Set<String> keys = new TreeSet<String>();
+        Iterator<?> iter = jsonObject.keys();
+        while(iter.hasNext()) {
+            keys.add((String)iter.next());
+        }
+        return keys;
+    }
+
+    public static String qualify(String prefix, String key) {
+        return "".equals(prefix) ? key : prefix + "." + key;
+    }
+
+    public static String formatUniqueKey(String key, String uniqueKey, Object value) {
+        return key + "[" + uniqueKey + "=" + value + "]";
+    }
+
+
+}

--- a/src/test/java/org/skyscreamer/jsonassert/comparator/CustomComparatorTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/comparator/CustomComparatorTest.java
@@ -1,0 +1,39 @@
+package org.skyscreamer.jsonassert.comparator;
+
+import junit.framework.Assert;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONCompare;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.JSONCompareResult;
+
+/**
+ * @author <a href="mailto:aiveeen@gmail.com">Ivan Zaytsev</a>
+ *         2013-01-04
+ */
+public class CustomComparatorTest {
+
+    private static class ArrayOfJsonObjectsComparator extends DefaultComparator {
+        public ArrayOfJsonObjectsComparator(JSONCompareMode mode) {
+            super(mode);
+        }
+
+        @Override
+        public void compareJSONArray(String prefix, JSONArray expected, JSONArray actual, JSONCompareResult result) throws JSONException {
+            compareJSONArrayOfJsonObjects(prefix, expected, actual, result);
+        }
+    }
+
+    @Test
+    public void testFullArrayComparison() throws Exception {
+        JSONCompareResult compareResult = JSONCompare.compareJSON(
+                "[{id:1}, {id:3}, {id:5}]",
+                "[{id:1}, {id:3}, {id:6}, {id:7}]", new ArrayOfJsonObjectsComparator(JSONCompareMode.LENIENT)
+        );
+
+        Assert.assertTrue(compareResult.failed());
+        String message = compareResult.getMessage().replaceAll("\n", "");
+        Assert.assertTrue(message, message.matches(".*id=5.*Expected.*id=6.*Unexpected.*id=7.*Unexpected.*"));
+    }
+}


### PR DESCRIPTION
This is quick and dirty implementation for #21. Many things are left to be done.

What is done:
- Extracted interface `JSONComparator`
- Extracted all logic from `JSONCompare`, now it is more like "service"
- `JSONCompareResult` now uses StringBuilder internally instead of String concatenation
