### PR TITLE
Custom comparator per path

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/Behavior.java
+++ b/src/main/java/org/skyscreamer/jsonassert/Behavior.java
@@ -77,4 +77,12 @@ public final class Behavior {
 	public Behavior with(Customization customization) {
 		return Builder.from(this).add(customization).build();
 	}
+
+    public Customization getCustomization(String path) {
+        for (Customization c : customizations) {
+            if (c.appliesToPath(path))
+                return c;
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/skyscreamer/jsonassert/Customization.java
+++ b/src/main/java/org/skyscreamer/jsonassert/Customization.java
@@ -4,14 +4,24 @@ import org.hamcrest.Matcher;
 
 public final class Customization {
 	private final String path;
-	private final Matcher<?> matcher;
+	private final EqualsComparator<Object> comparator;
 
-	public Customization(String path, Matcher<?> matcher) {
+	public Customization(String path, EqualsComparator<Object> comparator) {
+        assert path != null;
+        assert comparator != null;
 		this.path = path;
-		this.matcher = matcher;
+		this.comparator = comparator;
 	}
 
-	public static Customization customization(String path, Matcher<?> matcher) {
-		return new Customization(path, matcher);
+	public static Customization customization(String path, EqualsComparator<Object> comparator) {
+		return new Customization(path, comparator);
 	}
+
+    public boolean appliesToPath(String path) {
+        return this.path.equals(path);
+    }
+
+    public boolean matches(Object actual, Object expected) {
+        return comparator.equal(actual, expected);
+    }
 }

--- a/src/main/java/org/skyscreamer/jsonassert/EqualsComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/EqualsComparator.java
@@ -1,0 +1,7 @@
+package org.skyscreamer.jsonassert;
+
+public interface EqualsComparator<T> {
+
+    boolean equal(T o1, T o2);
+
+}

--- a/src/main/java/org/skyscreamer/jsonassert/HamcrestEqualsComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/HamcrestEqualsComparator.java
@@ -1,0 +1,27 @@
+package org.skyscreamer.jsonassert;
+
+import org.hamcrest.Matcher;
+
+/**
+ * Delegate equality comparison to an org.hamcrest.Matcher
+ * @param <T>
+ */
+public final class HamcrestEqualsComparator<T> implements EqualsComparator<T> {
+
+    private final Matcher<?> matcher;
+
+    public HamcrestEqualsComparator(Matcher<?> matcher) {
+        this.matcher = matcher;
+    }
+
+    /**
+     * The matcher is invoked on the first parameter, ignoring the second
+     * @param o1
+     * @param o2 ignored
+     * @return true if mather matches o1
+     */
+    @Override
+    public boolean equal(T o1, T o2) {
+        return matcher.matches(o1);
+    }
+}

--- a/src/main/java/org/skyscreamer/jsonassert/JSONCompare.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONCompare.java
@@ -122,7 +122,12 @@ public class JSONCompare {
 
     private static void compareValues(String fullKey, Object expectedValue, Object actualValue, Behavior behavior, JSONCompareResult result) throws JSONException
     {
-        if (expectedValue.getClass().isAssignableFrom(actualValue.getClass())) {
+        Customization customization = behavior.getCustomization(fullKey);
+        if (customization != null) {
+            if (!customization.matches(actualValue, expectedValue)) {
+                result.fail(fullKey, expectedValue, actualValue);
+            }
+        } else if (expectedValue.getClass().isAssignableFrom(actualValue.getClass())) {
             if (expectedValue instanceof JSONArray) {
                 compareJSONArray(fullKey , (JSONArray)expectedValue, (JSONArray)actualValue, behavior, result);
             }

--- a/src/test/java/org/skyscreamer/jsonassert/JSONBehaviourTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONBehaviourTest.java
@@ -1,0 +1,62 @@
+package org.skyscreamer.jsonassert;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.json.JSONException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.skyscreamer.jsonassert.Behavior.STRICT;
+import static org.skyscreamer.jsonassert.Customization.customization;
+import static org.skyscreamer.jsonassert.JSONCompare.compareJSON;
+
+public class JSONBehaviourTest {
+
+    String actual = "{\"first\":\"actual\", \"second\":1}";
+    String expected = "{\"first\":\"expected\", \"second\":1}";
+
+    String deepActual = "{\n" +
+            "    \"outer\":\n" +
+            "    {\n" +
+            "        \"inner\":\n" +
+            "        {\n" +
+            "            \"value\": \"actual\",\n" +
+            "            \"otherValue\": \"foo\"\n" +
+            "        }\n" +
+            "    }\n" +
+            "}";
+    String deepExpected = "{\n" +
+            "    \"outer\":\n" +
+            "    {\n" +
+            "        \"inner\":\n" +
+            "        {\n" +
+            "            \"value\": \"expected\",\n" +
+            "            \"otherValue\": \"foo\"\n" +
+            "        }\n" +
+            "    }\n" +
+            "}";
+
+    EqualsComparator<Object> comparator = new EqualsComparator<Object>() {
+        @Override
+        public boolean equal(Object o1, Object o2) {
+            return o1.toString().equals("actual") && o2.toString().equals("expected");
+        }
+    };
+
+    @Test
+    public void whenPathMatchesInCustomizationThenCallCustomMatcher() throws JSONException {
+        Behavior behavior = STRICT.with(customization("first", comparator));
+        JSONCompareResult result = compareJSON(expected, actual, behavior);
+        assertTrue(result.getMessage(),  result.passed());
+    }
+
+    @Test
+    public void whenDeepPathMatchesCallCustomMatcher() throws JSONException {
+        Behavior behavior = STRICT.with(customization("outer.inner.value", comparator));
+        JSONCompareResult result = compareJSON(deepExpected, deepActual, behavior);
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+}


### PR DESCRIPTION
Implement functionality to use custom comparators per specific path
elements. Current implementation is quite naive and can only match on
simple paths (no wildcards).

Updates the Customization class to allow path-matching, and matching of
expected and actual values with user-provided EqualityComparator.
