### PR TITLE
Custom comparator - in master

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/Customization.java
+++ b/src/main/java/org/skyscreamer/jsonassert/Customization.java
@@ -1,0 +1,28 @@
+package org.skyscreamer.jsonassert;
+
+/**
+ * Associates a custom matcher to a specific jsonpath.
+ */
+public final class Customization {
+	private final String path;
+	private final ValueMatcher<Object> comparator;
+
+	public Customization(String path, ValueMatcher<Object> comparator) {
+        assert path != null;
+        assert comparator != null;
+		this.path = path;
+		this.comparator = comparator;
+	}
+
+	public static Customization customization(String path, ValueMatcher<Object> comparator) {
+		return new Customization(path, comparator);
+	}
+
+    public boolean appliesToPath(String path) {
+        return this.path.equals(path);
+    }
+
+    public boolean matches(Object actual, Object expected) {
+        return comparator.equal(actual, expected);
+    }
+}

--- a/src/main/java/org/skyscreamer/jsonassert/ValueMatcher.java
+++ b/src/main/java/org/skyscreamer/jsonassert/ValueMatcher.java
@@ -1,0 +1,7 @@
+package org.skyscreamer.jsonassert;
+
+public interface ValueMatcher<T> {
+
+    boolean equal(T o1, T o2);
+
+}

--- a/src/main/java/org/skyscreamer/jsonassert/comparator/CustomComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/CustomComparator.java
@@ -1,0 +1,38 @@
+package org.skyscreamer.jsonassert.comparator;
+
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.Customization;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.JSONCompareResult;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public class CustomComparator extends DefaultComparator {
+
+    private final Collection<Customization> customizations;
+
+    public CustomComparator(JSONCompareMode mode,  Customization... customizations) {
+        super(mode);
+        this.customizations = Arrays.asList(customizations);
+    }
+
+    @Override
+    public void compareValues(String prefix, Object expectedValue, Object actualValue, JSONCompareResult result) throws JSONException {
+        Customization customization = getCustomization(prefix);
+        if (customization != null) {
+            if (!customization.matches(actualValue, expectedValue)) {
+                result.fail(prefix, expectedValue, actualValue);
+            }
+        } else {
+            super.compareValues(prefix, expectedValue, actualValue, result);
+        }
+    }
+
+    private Customization getCustomization(String path) {
+        for (Customization c : customizations)
+            if (c.appliesToPath(path))
+                return c;
+        return null;
+    }
+}

--- a/src/main/java/org/skyscreamer/jsonassert/comparator/DefaultComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/DefaultComparator.java
@@ -3,8 +3,14 @@ package org.skyscreamer.jsonassert.comparator;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.skyscreamer.jsonassert.Customization;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.skyscreamer.jsonassert.JSONCompareResult;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.skyscreamer.jsonassert.comparator.JSONCompareUtil.allJSONObjects;
 import static org.skyscreamer.jsonassert.comparator.JSONCompareUtil.allSimpleValues;

--- a/src/test/java/org/skyscreamer/jsonassert/JSONCustomComparatorTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONCustomComparatorTest.java
@@ -1,0 +1,63 @@
+package org.skyscreamer.jsonassert;
+
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
+import org.skyscreamer.jsonassert.comparator.JSONComparator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.skyscreamer.jsonassert.JSONCompare.compareJSON;
+
+public class JSONCustomComparatorTest {
+
+    String actual = "{\"first\":\"actual\", \"second\":1}";
+    String expected = "{\"first\":\"expected\", \"second\":1}";
+
+    String deepActual = "{\n" +
+            "    \"outer\":\n" +
+            "    {\n" +
+            "        \"inner\":\n" +
+            "        {\n" +
+            "            \"value\": \"actual\",\n" +
+            "            \"otherValue\": \"foo\"\n" +
+            "        }\n" +
+            "    }\n" +
+            "}";
+    String deepExpected = "{\n" +
+            "    \"outer\":\n" +
+            "    {\n" +
+            "        \"inner\":\n" +
+            "        {\n" +
+            "            \"value\": \"expected\",\n" +
+            "            \"otherValue\": \"foo\"\n" +
+            "        }\n" +
+            "    }\n" +
+            "}";
+
+    int comparatorCallCount = 0;
+    ValueMatcher<Object> comparator = new ValueMatcher<Object>() {
+        @Override
+        public boolean equal(Object o1, Object o2) {
+            comparatorCallCount++;
+            return o1.toString().equals("actual") && o2.toString().equals("expected");
+        }
+    };
+
+    @Test
+    public void whenPathMatchesInCustomizationThenCallCustomMatcher() throws JSONException {
+        JSONComparator jsonCmp = new CustomComparator(JSONCompareMode.STRICT, new Customization("first", comparator));
+        JSONCompareResult result = compareJSON(expected, actual, jsonCmp);
+        assertTrue(result.getMessage(),  result.passed());
+        assertEquals(1, comparatorCallCount);
+    }
+
+    @Test
+    public void whenDeepPathMatchesCallCustomMatcher() throws JSONException {
+        JSONComparator jsonCmp = new CustomComparator(JSONCompareMode.STRICT, new Customization("outer.inner.value", comparator));
+        JSONCompareResult result = compareJSON(deepExpected, deepActual, jsonCmp);
+        assertTrue(result.getMessage(), result.passed());
+        assertEquals(1, comparatorCallCount);
+    }
+
+}


### PR DESCRIPTION
Implement functionality to use custom comparators per specific path
elements. Current implementation is quite naive and can only match on
simple paths (no wildcards).

Updates the Customization class to allow path-matching, and matching of
expected and actual values with user-provided EqualityComparator.
