### PR TITLE
Change the implementation for org.json to one with a more open license

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ Who uses JSONassert?
 
 * * *
 
+org.json
+--------
+
+This implementation uses a clean-room implementation of the org.json
+library implemented for the Android system, released under the Apache 2.0 license. See
+[com.vaadin.external.google:android-json](http://search.maven.org/#artifactdetails%7Ccom.vaadin.external.google%7Candroid-json%7C0.0.20131108.vaadin1%7Cjar)
+That jar does **not** include the org.json.JSONString interface, so a new implementation of that interface is added to this source.
+
 Resources
 ---------
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>jsonassert</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JSONassert</name>
@@ -50,9 +50,9 @@
     <!-- For JSONAssert -->
     <dependencies>
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20090211</version>
+            <groupId>com.vaadin.external.google</groupId>
+            <artifactId>android-json</artifactId>
+            <version>0.0.20131108.vaadin1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/org/json/JSONString.java
+++ b/src/main/java/org/json/JSONString.java
@@ -1,0 +1,20 @@
+package org.json;
+
+/**
+ * The JSONString interface allows a toJSONString() method so that a class can change
+ * the behavior of JSONObject.toString(), JSONArray.toString(), and JSONWriter.value(Object). 
+ * The toJSONString method will be used instead of the default behavior of using the 
+ * Object's toString() method and quoting the result.
+ * 
+ * @author sasdjb
+ *
+ */
+public interface JSONString {
+
+    /**
+     * The toJSONString method allows a class to produce its own JSON 
+     * serialization.
+     * */
+    public String toJSONString();
+
+}


### PR DESCRIPTION
Use

   com.vaadin.external.google : android-json : 0.0.20131108.vaadin1

which has the Apache License 2.0 license:
http://www.apache.org/licenses/LICENSE-2.0

Add source for org.json.JSONString interface, which is missing from
the above bundle.

Addresses issue #44: non-free json.org code used
