### PR TITLE
Fixes #42 - overloaded methods to accept a message

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/JSONAssert.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONAssert.java
@@ -748,7 +748,7 @@ public class JSONAssert {
     private static String getCombinedMessage(String message1, String message2) {
         String combinedMessage = "";
         
-        if(message1 == null) {
+        if(message1 == null || "".equals(message1)) {
             combinedMessage = message2;
         } else {
             combinedMessage = message1 + " " + message2;

--- a/src/main/java/org/skyscreamer/jsonassert/JSONAssert.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONAssert.java
@@ -51,6 +51,21 @@ public class JSONAssert {
             throws JSONException {
         assertEquals(expectedStr, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
     }
+    
+    /**
+     * Asserts that the JSONObject provided matches the expected string.  If it isn't it throws an
+     * {@link AssertionError}.
+     *
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actual JSONObject to compare
+     * @param strict Enables strict checking
+     * @throws JSONException
+     */
+    public static void assertEquals(String message, String expectedStr, JSONObject actual, boolean strict)
+        throws JSONException {
+        assertEquals(message, expectedStr, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
+    }
 
     /**
      * Asserts that the JSONObject provided does not match the expected string.  If it is it throws an
@@ -67,6 +82,23 @@ public class JSONAssert {
             throws JSONException {
         assertNotEquals(expectedStr, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
     }
+    
+    /**
+     * Asserts that the JSONObject provided does not match the expected string.  If it is it throws an
+     * {@link AssertionError}.
+     * 
+     * @see #assertEquals(String JSONObject, boolean)
+     * 
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actual JSONObject to compare
+     * @param strict Enables strict checking
+     * @throws JSONException
+     */
+    public static void assertNotEquals(String message, String expectedStr, JSONObject actual, boolean strict)
+        throws JSONException {
+        assertNotEquals(message, expectedStr, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
+    }
 
     /**
      * Asserts that the JSONObject provided matches the expected string.  If it isn't it throws an
@@ -79,9 +111,24 @@ public class JSONAssert {
      */
     public static void assertEquals(String expectedStr, JSONObject actual, JSONCompareMode compareMode)
             throws JSONException {
+        assertEquals("", expectedStr, actual, compareMode);
+    }
+    
+    /**
+     * Asserts that the JSONObject provided matches the expected string.  If it isn't it throws an
+     * {@link AssertionError}.
+     *
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actual JSONObject to compare
+     * @param compareMode Specifies which comparison mode to use
+     * @throws JSONException
+     */
+    public static void assertEquals(String message, String expectedStr, JSONObject actual, JSONCompareMode compareMode)
+        throws JSONException {
         Object expected = JSONParser.parseJSON(expectedStr);
         if (expected instanceof JSONObject) {
-            assertEquals((JSONObject)expected, actual, compareMode);
+            assertEquals(message, (JSONObject)expected, actual, compareMode);
         }
         else {
             throw new AssertionError("Expecting a JSON array, but passing in a JSON object");
@@ -101,9 +148,26 @@ public class JSONAssert {
      */
     public static void assertNotEquals(String expectedStr, JSONObject actual, JSONCompareMode compareMode)
             throws JSONException {
+        assertNotEquals("", expectedStr, actual, compareMode);
+    }
+    
+    /**
+     * Asserts that the JSONObject provided does not match the expected string.  If it is it throws an
+     * {@link AssertionError}.
+     * 
+     * @see #assertEquals(String, JSONObject, JSONCompareMode)
+     * 
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actual JSONObject to compare
+     * @param compareMode Specifies which comparison mode to use
+     * @throws JSONException
+     */
+    public static void assertNotEquals(String message, String expectedStr, JSONObject actual, JSONCompareMode compareMode)
+        throws JSONException {
         Object expected = JSONParser.parseJSON(expectedStr);
         if (expected instanceof JSONObject) {
-            assertNotEquals((JSONObject) expected, actual, compareMode);
+            assertNotEquals(message, (JSONObject) expected, actual, compareMode);
         }
         else {
             throw new AssertionError("Expecting a JSON array, but passing in a JSON object");
@@ -123,6 +187,21 @@ public class JSONAssert {
             throws JSONException {
         assertEquals(expectedStr, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
     }
+    
+    /**
+     * Asserts that the JSONArray provided matches the expected string.  If it isn't it throws an
+     * {@link AssertionError}.
+     *
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actual JSONArray to compare
+     * @param strict Enables strict checking
+     * @throws JSONException
+     */
+    public static void assertEquals(String message, String expectedStr, JSONArray actual, boolean strict)
+        throws JSONException {
+        assertEquals(message, expectedStr, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
+    }
 
     /**
      * Asserts that the JSONArray provided does not match the expected string.  If it is it throws an
@@ -137,6 +216,21 @@ public class JSONAssert {
             throws JSONException {
         assertNotEquals(expectedStr, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
     }
+    
+    /**
+     * Asserts that the JSONArray provided does not match the expected string.  If it is it throws an
+     * {@link AssertionError}.
+     * 
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actual JSONArray to compare
+     * @param strict Enables strict checking
+     * @throws JSONException
+     */
+    public static void assertNotEquals(String message, String expectedStr, JSONArray actual, boolean strict)
+        throws JSONException {
+        assertNotEquals(message, expectedStr, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
+    }
 
     /**
      * Asserts that the JSONArray provided matches the expected string.  If it isn't it throws an
@@ -149,9 +243,24 @@ public class JSONAssert {
      */
     public static void assertEquals(String expectedStr, JSONArray actual, JSONCompareMode compareMode)
             throws JSONException {
+        assertEquals("", expectedStr, actual, compareMode);
+    }
+    
+    /**
+     * Asserts that the JSONArray provided matches the expected string.  If it isn't it throws an
+     * {@link AssertionError}.
+     *
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actual JSONArray to compare
+     * @param compareMode Specifies which comparison mode to use
+     * @throws JSONException
+     */
+    public static void assertEquals(String message, String expectedStr, JSONArray actual, JSONCompareMode compareMode)
+        throws JSONException {
         Object expected = JSONParser.parseJSON(expectedStr);
         if (expected instanceof JSONArray) {
-            assertEquals((JSONArray) expected, actual, compareMode);
+            assertEquals(message, (JSONArray) expected, actual, compareMode);
         }
         else {
             throw new AssertionError("Expecting a JSON object, but passing in a JSON array");
@@ -177,6 +286,27 @@ public class JSONAssert {
             throw new AssertionError("Expecting a JSON object, but passing in a JSON array");
         }
     }
+    
+    /**
+     * Asserts that the JSONArray provided does not match the expected string.  If it is it throws an
+     * {@link AssertionError}.
+     * 
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actual JSONArray to compare
+     * @param compareMode Specifies which comparison mode to use
+     * @throws JSONException
+     */
+    public static void assertNotEquals(String message, String expectedStr, JSONArray actual, JSONCompareMode compareMode)
+        throws JSONException {
+        Object expected = JSONParser.parseJSON(expectedStr);
+        if (expected instanceof JSONArray) {
+            assertNotEquals(message, (JSONArray) expected, actual, compareMode);
+        }
+        else {
+            throw new AssertionError("Expecting a JSON object, but passing in a JSON array");
+        }
+    }
 
     /**
      * Asserts that the JSONArray provided matches the expected string.  If it isn't it throws an
@@ -190,6 +320,21 @@ public class JSONAssert {
     public static void assertEquals(String expectedStr, String actualStr, boolean strict)
             throws JSONException {
         assertEquals(expectedStr, actualStr, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
+    }
+    
+    /**
+     * Asserts that the JSONArray provided matches the expected string.  If it isn't it throws an
+     * {@link AssertionError}.
+     *
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actualStr String to compare
+     * @param strict Enables strict checking
+     * @throws JSONException
+     */
+    public static void assertEquals(String message, String expectedStr, String actualStr, boolean strict)
+        throws JSONException {
+        assertEquals(message, expectedStr, actualStr, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
     }
 
     /**
@@ -205,6 +350,21 @@ public class JSONAssert {
             throws JSONException {
         assertNotEquals(expectedStr, actualStr, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
     }
+    
+    /**
+     * Asserts that the JSONArray provided does not match the expected string.  If it is it throws an
+     * {@link AssertionError}.
+     * 
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actualStr String to compare
+     * @param strict Enables strict checking
+     * @throws JSONException
+     */
+    public static void assertNotEquals(String message, String expectedStr, String actualStr, boolean strict)
+        throws JSONException {
+        assertNotEquals(message, expectedStr, actualStr, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
+    }
 
     /**
      * Asserts that the JSONArray provided matches the expected string.  If it isn't it throws an
@@ -217,6 +377,21 @@ public class JSONAssert {
      */
     public static void assertEquals(String expectedStr, String actualStr, JSONCompareMode compareMode)
             throws JSONException {
+        assertEquals("", expectedStr, actualStr, compareMode);
+    }
+    
+    /**
+     * Asserts that the JSONArray provided matches the expected string.  If it isn't it throws an
+     * {@link AssertionError}.
+     *
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actualStr String to compare
+     * @param compareMode Specifies which comparison mode to use
+     * @throws JSONException
+     */
+    public static void assertEquals(String message, String expectedStr, String actualStr, JSONCompareMode compareMode)
+        throws JSONException {
         if (expectedStr==actualStr) return;
         if (expectedStr==null){
             throw new AssertionError("Expected string is null.");
@@ -225,7 +400,7 @@ public class JSONAssert {
         }
         JSONCompareResult result = JSONCompare.compareJSON(expectedStr, actualStr, compareMode);
         if (result.failed()) {
-            throw new AssertionError(result.getMessage());
+            throw new AssertionError(getCombinedMessage(message, result.getMessage()));
         }
     }
 
@@ -240,9 +415,24 @@ public class JSONAssert {
      */
     public static void assertNotEquals(String expectedStr, String actualStr, JSONCompareMode compareMode)
             throws JSONException {
+        assertNotEquals("", expectedStr, actualStr, compareMode);
+    }
+    
+    /**
+     * Asserts that the JSONArray provided does not match the expected string.  If it is it throws an
+     * {@link AssertionError}.
+     * 
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actualStr String to compare
+     * @param compareMode Specifies which comparison mode to use
+     * @throws JSONException
+     */
+    public static void assertNotEquals(String message, String expectedStr, String actualStr, JSONCompareMode compareMode)
+        throws JSONException {
         JSONCompareResult result = JSONCompare.compareJSON(expectedStr, actualStr, compareMode);
         if (result.passed()) {
-            throw new AssertionError(result.getMessage());
+            throw new AssertionError(getCombinedMessage(message, result.getMessage()));
         }
     }
 
@@ -257,9 +447,25 @@ public class JSONAssert {
      */
     public static void assertEquals(String expectedStr, String actualStr, JSONComparator comparator)
             throws JSONException {
+        assertEquals("", expectedStr, actualStr, comparator);
+        
+    }
+    
+    /**
+     * Asserts that the json string provided matches the expected string.  If it isn't it throws an
+     * {@link AssertionError}.
+     *
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actualStr String to compare
+     * @param comparator Comparator
+     * @throws JSONException
+     */
+    public static void assertEquals(String message, String expectedStr, String actualStr, JSONComparator comparator)
+        throws JSONException {
         JSONCompareResult result = JSONCompare.compareJSON(expectedStr, actualStr, comparator);
         if (result.failed()) {
-            throw new AssertionError(result.getMessage());
+            throw new AssertionError(getCombinedMessage(message, result.getMessage()));
         }
     }
 
@@ -274,9 +480,24 @@ public class JSONAssert {
      */
     public static void assertNotEquals(String expectedStr, String actualStr, JSONComparator comparator)
             throws JSONException {
+        assertNotEquals("", expectedStr, actualStr, comparator);
+    }
+    
+    /**
+     * Asserts that the json string provided does not match the expected string.  If it is it throws an
+     * {@link AssertionError}.
+     * 
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expectedStr Expected JSON string
+     * @param actualStr String to compare
+     * @param comparator Comparator
+     * @throws JSONException
+     */
+    public static void assertNotEquals(String message, String expectedStr, String actualStr, JSONComparator comparator)
+        throws JSONException {
         JSONCompareResult result = JSONCompare.compareJSON(expectedStr, actualStr, comparator);
         if (result.passed()) {
-            throw new AssertionError(result.getMessage());
+            throw new AssertionError(getCombinedMessage(message, result.getMessage()));
         }
     }
 
@@ -293,6 +514,21 @@ public class JSONAssert {
             throws JSONException {
         assertEquals(expected, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
     }
+    
+    /**
+     * Asserts that the JSONObject provided matches the expected JSONObject.  If it isn't it throws an
+     * {@link AssertionError}.
+     *
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expected Expected JSONObject
+     * @param actual JSONObject to compare
+     * @param strict Enables strict checking
+     * @throws JSONException
+     */
+    public static void assertEquals(String message, JSONObject expected, JSONObject actual, boolean strict)
+        throws JSONException {
+        assertEquals(message, expected, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
+    }
 
     /**
      * Asserts that the JSONObject provided does not match the expected JSONObject.  If it is it throws an
@@ -307,6 +543,21 @@ public class JSONAssert {
             throws JSONException {
         assertNotEquals(expected, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
     }
+    
+    /**
+     * Asserts that the JSONObject provided does not match the expected JSONObject.  If it is it throws an
+     * {@link AssertionError}.
+     * 
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expected Expected JSONObject
+     * @param actual JSONObject to compare
+     * @param strict Enables strict checking
+     * @throws JSONException
+     */
+    public static void assertNotEquals(String message, JSONObject expected, JSONObject actual, boolean strict)
+        throws JSONException {
+        assertNotEquals(message, expected, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
+    }
 
     /**
      * Asserts that the JSONObject provided matches the expected JSONObject.  If it isn't it throws an
@@ -318,11 +569,25 @@ public class JSONAssert {
      * @throws JSONException
      */
     public static void assertEquals(JSONObject expected, JSONObject actual, JSONCompareMode compareMode)
-            throws JSONException
-    {
+            throws JSONException {
+        assertEquals("", expected, actual, compareMode);
+    }
+    
+    /**
+     * Asserts that the JSONObject provided matches the expected JSONObject.  If it isn't it throws an
+     * {@link AssertionError}.
+     *
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expected Expected JSONObject
+     * @param actual JSONObject to compare
+     * @param compareMode Specifies which comparison mode to use
+     * @throws JSONException
+     */
+    public static void assertEquals(String message, JSONObject expected, JSONObject actual, JSONCompareMode compareMode)
+        throws JSONException {
         JSONCompareResult result = JSONCompare.compareJSON(expected, actual, compareMode);
         if (result.failed()) {
-            throw new AssertionError(result.getMessage());
+            throw new AssertionError(getCombinedMessage(message, result.getMessage()));
         }
     }
 
@@ -336,11 +601,25 @@ public class JSONAssert {
      * @throws JSONException
      */
     public static void assertNotEquals(JSONObject expected, JSONObject actual, JSONCompareMode compareMode)
-            throws JSONException
-    {
+            throws JSONException {
+        assertNotEquals("", expected, actual, compareMode);
+    }
+    
+    /**
+     * Asserts that the JSONObject provided does not match the expected JSONObject.  If it is it throws an
+     * {@link AssertionError}.
+     * 
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expected Expected JSONObject
+     * @param actual JSONObject to compare
+     * @param compareMode Specifies which comparison mode to use
+     * @throws JSONException
+     */
+    public static void assertNotEquals(String message, JSONObject expected, JSONObject actual, JSONCompareMode compareMode)
+        throws JSONException {
         JSONCompareResult result = JSONCompare.compareJSON(expected, actual, compareMode);
         if (result.passed()) {
-            throw new AssertionError(result.getMessage());
+            throw new AssertionError(getCombinedMessage(message, result.getMessage()));
         }
     }
 
@@ -355,7 +634,22 @@ public class JSONAssert {
      */
     public static void assertEquals(JSONArray expected, JSONArray actual, boolean strict)
             throws JSONException {
-        assertEquals(expected, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
+        assertEquals("", expected, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
+    }
+    
+    /**
+     * Asserts that the JSONArray provided matches the expected JSONArray.  If it isn't it throws an
+     * {@link AssertionError}.
+     *
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expected Expected JSONArray
+     * @param actual JSONArray to compare
+     * @param strict Enables strict checking
+     * @throws JSONException
+     */
+    public static void assertEquals(String message, JSONArray expected, JSONArray actual, boolean strict)
+        throws JSONException {
+        assertEquals(message, expected, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
     }
 
     /**
@@ -371,6 +665,21 @@ public class JSONAssert {
             throws JSONException {
         assertNotEquals(expected, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
     }
+    
+    /**
+     * Asserts that the JSONArray provided does not match the expected JSONArray.  If it is it throws an
+     * {@link AssertionError}.
+     * 
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expected Expected JSONArray
+     * @param actual JSONArray to compare
+     * @param strict Enables strict checking
+     * @throws JSONException
+     */
+    public static void assertNotEquals(String message, JSONArray expected, JSONArray actual, boolean strict)
+        throws JSONException {
+        assertNotEquals(message, expected, actual, strict ? JSONCompareMode.STRICT : JSONCompareMode.LENIENT);
+    }
 
     /**
      * Asserts that the JSONArray provided matches the expected JSONArray.  If it isn't it throws an
@@ -383,9 +692,24 @@ public class JSONAssert {
      */
     public static void assertEquals(JSONArray expected, JSONArray actual, JSONCompareMode compareMode)
             throws JSONException {
+        assertEquals("", expected, actual, compareMode);
+    }
+    
+    /**
+     * Asserts that the JSONArray provided matches the expected JSONArray.  If it isn't it throws an
+     * {@link AssertionError}.
+     *
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expected Expected JSONArray
+     * @param actual JSONArray to compare
+     * @param compareMode Specifies which comparison mode to use
+     * @throws JSONException
+     */
+    public static void assertEquals(String message, JSONArray expected, JSONArray actual, JSONCompareMode compareMode)
+        throws JSONException {
         JSONCompareResult result = JSONCompare.compareJSON(expected, actual, compareMode);
         if (result.failed()) {
-            throw new AssertionError(result.getMessage());
+            throw new AssertionError(getCombinedMessage(message, result.getMessage()));
         }
     }
 
@@ -400,9 +724,35 @@ public class JSONAssert {
      */
     public static void assertNotEquals(JSONArray expected, JSONArray actual, JSONCompareMode compareMode)
             throws JSONException {
+        assertNotEquals("", expected, actual, compareMode);
+    }
+    
+    /**
+     * Asserts that the JSONArray provided does not match the expected JSONArray.  If it is it throws an
+     * {@link AssertionError}.
+     * 
+     * @param message Error message to be displayed in case of assertion failure
+     * @param expected Expected JSONArray
+     * @param actual JSONArray to compare
+     * @param compareMode Specifies which comparison mode to use
+     * @throws JSONException
+     */
+    public static void assertNotEquals(String message, JSONArray expected, JSONArray actual, JSONCompareMode compareMode)
+        throws JSONException {
         JSONCompareResult result = JSONCompare.compareJSON(expected, actual, compareMode);
         if (result.passed()) {
-            throw new AssertionError(result.getMessage());
+            throw new AssertionError(getCombinedMessage(message, result.getMessage()));
         }
+    }
+    
+    private static String getCombinedMessage(String message1, String message2) {
+        String combinedMessage = "";
+        
+        if(message1 == null) {
+            combinedMessage = message2;
+        } else {
+            combinedMessage = message1 + " " + message2;
+        }
+        return combinedMessage;
     }
 }

--- a/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
@@ -379,24 +379,24 @@ public class JSONAssertTest {
     public void testAssertEqualsStringJSONArrayBooleanWithMessage() throws JSONException {
         JSONArray actual = new JSONArray(Arrays.asList(1, 2, 3));
         JSONAssert.assertEquals("Message", "[1,2,3]", actual, false);
-        performTestForMessageVerification("[1,2,4]", actual, false);
-        performTestForMessageVerification("[1,3,2]", actual, true);
+        performAssertEqualsTestForMessageVerification("[1,2,4]", actual, false);
+        performAssertEqualsTestForMessageVerification("[1,3,2]", actual, true);
     }
     
     @Test
     public void testAssertEqualsStringJSONArrayCompareModeWithMessage() throws JSONException {
         JSONArray actual = new JSONArray(Arrays.asList(1, 2, 3));
         JSONAssert.assertEquals("Message", "[1,2,3]", actual, LENIENT);
-        performTestForMessageVerification("[1,2,4]", actual, LENIENT);
-        performTestForMessageVerification("[1,3,2]", actual, STRICT);
+        performAssertEqualsTestForMessageVerification("[1,2,4]", actual, LENIENT);
+        performAssertEqualsTestForMessageVerification("[1,3,2]", actual, STRICT);
     }
-    
+
     @Test
     public void testAssertEqualsJSONArray2BooleanWithMessage() throws JSONException {
         JSONArray actual = new JSONArray(Arrays.asList(1, 2, 3));
         JSONAssert.assertEquals("Message", new JSONArray(Arrays.asList(1, 2, 3)), actual, false);
-        performTestForMessageVerification(new JSONArray(Arrays.asList(1, 2, 4)), actual, false);
-        performTestForMessageVerification(new JSONArray(Arrays.asList(1, 3, 2)), actual, true);
+        performAssertEqualsTestForMessageVerification(new JSONArray(Arrays.asList(1, 2, 4)), actual, false);
+        performAssertEqualsTestForMessageVerification(new JSONArray(Arrays.asList(1, 3, 2)), actual, true);
     }
     
     @Test
@@ -404,9 +404,8 @@ public class JSONAssertTest {
         JSONArray actual = new JSONArray(Arrays.asList(1, 2, 3));
         
         JSONAssert.assertEquals("Message", new JSONArray(Arrays.asList(1, 2, 3)), actual, LENIENT);
-        performTestForMessageVerification(new JSONArray(Arrays.asList(1, 2, 4)), actual, LENIENT);
-        performTestForMessageVerification(new JSONArray(Arrays.asList(1, 3, 2)), actual, STRICT);
-
+        performAssertEqualsTestForMessageVerification(new JSONArray(Arrays.asList(1, 2, 4)), actual, LENIENT);
+        performAssertEqualsTestForMessageVerification(new JSONArray(Arrays.asList(1, 3, 2)), actual, STRICT);
     }
     
     @Test
@@ -414,8 +413,8 @@ public class JSONAssertTest {
         JSONAssert.assertEquals("Message", "{id:12345}", "{id:12345}", false);
         JSONAssert.assertEquals("Message", "{id:12345}", "{id:12345, name:\"john\"}", false);
         
-        performTestForMessageVerification("{id:12345}", "{id:12345, name:\"john\"}", true);
-        performTestForMessageVerification("{id:12345}", "{id:123456}", false);
+        performAssertEqualsTestForMessageVerification("{id:12345}", "{id:12345, name:\"john\"}", true);
+        performAssertEqualsTestForMessageVerification("{id:12345}", "{id:123456}", false);
     }
     
     @Test
@@ -423,8 +422,8 @@ public class JSONAssertTest {
         JSONAssert.assertEquals("Message", "{id:12345}", "{id:12345}", LENIENT);
         JSONAssert.assertEquals("Message", "{id:12345}", "{id:12345, name:\"john\"}", LENIENT);
         
-        performTestForMessageVerification("{id:12345}", "{id:12345, name:\"john\"}", STRICT);
-        performTestForMessageVerification("{id:12345}", "{id:123456}", LENIENT);
+        performAssertEqualsTestForMessageVerification("{id:12345}", "{id:12345, name:\"john\"}", STRICT);
+        performAssertEqualsTestForMessageVerification("{id:12345}", "{id:123456}", LENIENT);
     }
     
     @Test
@@ -432,8 +431,8 @@ public class JSONAssertTest {
         JSONObject actual = new JSONObject();
         actual.put("id", Double.valueOf(12345));
         JSONAssert.assertEquals("Message", "{id:12345}", actual, false);
-        performTestForMessageVerification("{id:12346}", actual, false);
-        performTestForMessageVerification("[1,2,3]", "[1,3,2]", true);
+        performAssertEqualsTestForMessageVerification("{id:12346}", actual, false);
+        performAssertEqualsTestForMessageVerification("[1,2,3]", "[1,3,2]", true);
     }
     
     @Test
@@ -441,8 +440,8 @@ public class JSONAssertTest {
         JSONObject actual = new JSONObject();
         actual.put("id", Double.valueOf(12345));
         JSONAssert.assertEquals("Message", "{id:12345}", actual, LENIENT);
-        performTestForMessageVerification("{id:12346}", actual, LENIENT);
-        performTestForMessageVerification("[1,2,3]", "[1,3,2]", STRICT);
+        performAssertEqualsTestForMessageVerification("{id:12346}", actual, LENIENT);
+        performAssertEqualsTestForMessageVerification("[1,2,3]", "[1,3,2]", STRICT);
     }
     
     @Test
@@ -455,13 +454,13 @@ public class JSONAssertTest {
         JSONAssert.assertEquals("Message", expected, actual, LENIENT);
         
         expected.put("street", "St. Paul");
-        performTestForMessageVerification(expected, actual, LENIENT);
+        performAssertEqualsTestForMessageVerification(expected, actual, LENIENT);
         
         expected = new JSONObject();
         actual = new JSONObject();
         expected.put("id", Integer.valueOf(12345));
         actual.put("id", Double.valueOf(12346));
-        performTestForMessageVerification(expected, actual, STRICT);
+        performAssertEqualsTestForMessageVerification(expected, actual, STRICT);
     }
     
     @Test
@@ -474,13 +473,13 @@ public class JSONAssertTest {
         JSONAssert.assertEquals("Message", expected, actual, false);
         
         expected.put("street", "St. Paul");
-        performTestForMessageVerification(expected, actual, false);
+        performAssertEqualsTestForMessageVerification(expected, actual, false);
         
         expected = new JSONObject();
         actual = new JSONObject();
         expected.put("id", Integer.valueOf(12345));
         actual.put("id", Double.valueOf(12346));
-        performTestForMessageVerification(expected, actual, true);
+        performAssertEqualsTestForMessageVerification(expected, actual, true);
     }
     
     @Test
@@ -492,7 +491,135 @@ public class JSONAssertTest {
                 new RegularExpressionValueMatcher<Object>("\\d"))
          ));
         
-        performTestForMessageVerification("{\"entry\":{\"id\":x}}", "{\"entry\":{\"id\":1, \"id\":as}}", 
+        performAssertEqualsTestForMessageVerification("{\"entry\":{\"id\":x}}", "{\"entry\":{\"id\":1, \"id\":as}}", 
+            new CustomComparator(
+                JSONCompareMode.STRICT, 
+                new Customization("entry.id", 
+                new RegularExpressionValueMatcher<Object>("\\d"))
+        ));
+    }
+    
+    @Test
+    public void testAssertNotEqualsStringJSONArrayBooleanWithMessage() throws JSONException {
+        JSONArray actual = new JSONArray(Arrays.asList(1, 2, 3));
+        JSONAssert.assertNotEquals("Message", "[1,4,3]", actual, false);
+        JSONAssert.assertNotEquals("Message", "[1,4,3]", actual, true);
+        performAssertNotEqualsTestForMessageVerification("[1,3,2]", actual, false);
+        performAssertNotEqualsTestForMessageVerification("[1,2,3]", actual, true);
+    }
+    
+    @Test
+    public void testAssertNotEqualsStringJSONArrayCompareModeWithMessage() throws JSONException {
+        JSONArray actual = new JSONArray(Arrays.asList(1, 2, 3));
+        JSONAssert.assertNotEquals("Message", "[1,2,4]", actual, LENIENT);
+        JSONAssert.assertNotEquals("Message", "[1,2,4]", actual, STRICT);
+        performAssertNotEqualsTestForMessageVerification("[1,3,2]", actual, LENIENT);
+        performAssertNotEqualsTestForMessageVerification("[1,2,3]", actual, STRICT);
+    }
+    
+    @Test
+    public void testAssertNotEqualsJSONArray2BooleanWithMessage() throws JSONException {
+        JSONArray actual = new JSONArray(Arrays.asList(1, 2, 3));
+        JSONAssert.assertNotEquals("Message", new JSONArray(Arrays.asList(1, 4, 3)), actual, false);
+        performAssertNotEqualsTestForMessageVerification(new JSONArray(Arrays.asList(1, 3, 2)), actual, false);
+        performAssertNotEqualsTestForMessageVerification(new JSONArray(Arrays.asList(1, 2, 3)), actual, true);
+    }
+    
+    @Test
+    public void testAssertNotEqualsJSONArray2JSONCompareWithMessage() throws JSONException {
+        JSONArray actual = new JSONArray(Arrays.asList(1, 2, 3));
+        
+        JSONAssert.assertNotEquals("Message", new JSONArray(Arrays.asList(1, 4, 3)), actual, LENIENT);
+        performAssertNotEqualsTestForMessageVerification(new JSONArray(Arrays.asList(1, 3, 2)), actual, LENIENT);
+        performAssertNotEqualsTestForMessageVerification(new JSONArray(Arrays.asList(1, 2, 3)), actual, STRICT);
+    }
+    
+    @Test
+    public void testAssertNotEqualsString2Boolean() throws JSONException {
+        JSONAssert.assertNotEquals("Message", "{id:12345}", "{id:45}", false);
+        JSONAssert.assertNotEquals("Message", "{id:12345}", "{id:345, name:\"john\"}", false);
+        
+        performAssertNotEqualsTestForMessageVerification("{id:12345}", "{id:12345}", true);
+        performAssertNotEqualsTestForMessageVerification("{id:12345}", "{id:12345, name:\"John\"}", false);
+    }
+    
+    @Test
+    public void testAssertNotEqualsString2JSONCompare() throws JSONException {
+        JSONAssert.assertNotEquals("Message", "{id:12345}", "{id:123}", LENIENT);
+        JSONAssert.assertNotEquals("Message", "{id:12345, name:\"John\"}", "{id:12345}", LENIENT);
+        
+        performAssertNotEqualsTestForMessageVerification("{id:12345}", "{id:12345, name:\"john\"}", LENIENT);
+        performAssertNotEqualsTestForMessageVerification("{id:12345}", "{id:12345}", STRICT);
+    }
+    
+    @Test
+    public void testAssertNotEqualsStringJSONObjectBoolean() throws JSONException {
+        JSONObject actual = new JSONObject();
+        actual.put("id", Double.valueOf(12345));
+        JSONAssert.assertNotEquals("Message", "{id:1234}", actual, false);
+        performAssertNotEqualsTestForMessageVerification("{id:12345}", actual, false);
+        performAssertNotEqualsTestForMessageVerification("[1,2,3]", "[1,2,3]", true);
+    }
+    
+    @Test
+    public void testAssertNotEqualsStringJSONObjectJSONCompare() throws JSONException {
+        JSONObject actual = new JSONObject();
+        actual.put("id", Double.valueOf(12345));
+        JSONAssert.assertNotEquals("Message", "{id:1234}", actual, LENIENT);
+        performAssertNotEqualsTestForMessageVerification("{id:12345}", actual, LENIENT);
+        performAssertNotEqualsTestForMessageVerification("[1,2,3]", "[1,2,3]", STRICT);
+    }
+    
+    @Test
+    public void testAssertNtEqualsJSONObject2JSONCompare() throws JSONException {
+        JSONObject expected = new JSONObject();
+        JSONObject actual = new JSONObject();
+        expected.put("id", Integer.valueOf(12345));
+        actual.put("name", "Joe");
+        actual.put("id", Integer.valueOf(123));
+        JSONAssert.assertNotEquals("Message", expected, actual, LENIENT);
+        
+        actual.remove("id");
+        actual.put("id", Integer.valueOf(12345));
+        performAssertNotEqualsTestForMessageVerification(expected, actual, LENIENT);
+        
+        expected = new JSONObject();
+        actual = new JSONObject();
+        expected.put("id", Integer.valueOf(12345));
+        actual.put("id", Double.valueOf(12345));
+        performAssertNotEqualsTestForMessageVerification(expected, actual, STRICT);
+    }
+    
+    @Test
+    public void testAssertNotEqualsJSONObject2Boolean() throws JSONException {
+        JSONObject expected = new JSONObject();
+        JSONObject actual = new JSONObject();
+        expected.put("id", Integer.valueOf(12345));
+        actual.put("name", "Joe");
+        actual.put("id", Integer.valueOf(123));
+        JSONAssert.assertNotEquals("Message", expected, actual, false);
+        
+        actual.remove("id");
+        actual.put("id", Integer.valueOf(12345));
+        performAssertNotEqualsTestForMessageVerification(expected, actual, false);
+        
+        expected = new JSONObject();
+        actual = new JSONObject();
+        expected.put("id", Integer.valueOf(12345));
+        actual.put("id", Double.valueOf(12345));
+        performAssertNotEqualsTestForMessageVerification(expected, actual, true);
+    }
+    
+    @Test
+    public void testAssertNotEqualsString2JsonComparator() throws IllegalArgumentException, JSONException {
+        JSONAssert.assertNotEquals("Message", "{\"entry\":{\"id\":x}}", "{\"entry\":{\"id\":1, \"id\":hh}}", 
+            new CustomComparator(
+                JSONCompareMode.STRICT, 
+                new Customization("entry.id", 
+                new RegularExpressionValueMatcher<Object>("\\d"))
+         ));
+        
+        performAssertNotEqualsTestForMessageVerification("{\"entry\":{\"id\":x}}", "{\"entry\":{\"id\":1, \"id\":2}}", 
             new CustomComparator(
                 JSONCompareMode.STRICT, 
                 new Customization("entry.id", 
@@ -516,7 +643,11 @@ public class JSONAssertTest {
         Assert.assertTrue(message, result.failed());
     }
     
-    private void performTestForMessageVerification(Object expected, Object actual, Object strictMode) throws JSONException {
+    private void performAssertEqualsTestForMessageVerification(
+        Object expected, 
+        Object actual, 
+        Object strictMode) throws JSONException {
+        
         String message = "Message";
         String testShouldFailMessage = "The test should fail so that the message in AssertionError could be verified.";
         String strictModeMessage = "strictMode must be an instance of JSONCompareMode or Boolean";
@@ -592,6 +723,100 @@ public class JSONAssertTest {
                     JSONAssert.assertEquals(message, (JSONObject) expected, (JSONObject) actual, (JSONCompareMode) strictMode);
                 } else if(strictMode instanceof Boolean) {
                     JSONAssert.assertEquals(message, (JSONObject) expected, (JSONObject) actual, (Boolean) strictMode);
+                } else {
+                    fail(strictModeMessage);
+                }
+                assertEqualsFailed = false;
+                fail(testShouldFailMessage); //will throw AssertionError
+            } catch (AssertionError ae) {
+                handleAssertionError(message, assertEqualsFailed, ae);
+            }
+        } else {
+            fail("No overloaded method found to call");
+        }
+    }
+    
+    private void performAssertNotEqualsTestForMessageVerification(
+        Object expected, 
+        Object actual, 
+        Object strictMode) 
+        throws JSONException {
+        
+        String message = "Message";
+        String testShouldFailMessage = "The test should fail so that the message in AssertionError could be verified.";
+        String strictModeMessage = "strictMode must be an instance of JSONCompareMode or Boolean";
+        boolean assertEqualsFailed = true;
+        if(expected instanceof String && actual instanceof String && strictMode instanceof JSONComparator) {
+            try {
+                JSONAssert.assertNotEquals(message, (String) expected, (String) actual, (JSONComparator) strictMode);
+                assertEqualsFailed = false;
+                fail(testShouldFailMessage); //will throw AssertionError
+            } catch (AssertionError ae) {
+                handleAssertionError(message, assertEqualsFailed, ae);
+            }
+        }
+        else if(expected instanceof String && actual instanceof JSONArray) {
+            try {
+                if(strictMode instanceof JSONCompareMode) {
+                    JSONAssert.assertNotEquals(message, (String) expected, (JSONArray) actual, (JSONCompareMode) strictMode);
+                } else if(strictMode instanceof Boolean) {
+                    JSONAssert.assertNotEquals(message, (String) expected, (JSONArray) actual, (Boolean) strictMode);
+                } else {
+                    fail(strictModeMessage);
+                }
+                assertEqualsFailed = false;
+                fail(testShouldFailMessage); //will throw AssertionError
+            } catch (AssertionError ae) {
+                handleAssertionError(message, assertEqualsFailed, ae);
+            }
+        } else if(expected instanceof JSONArray && actual instanceof JSONArray) {
+            try {
+                if(strictMode instanceof JSONCompareMode) {
+                    JSONAssert.assertNotEquals(message, (JSONArray) expected, (JSONArray) actual, (JSONCompareMode) strictMode);
+                } else if(strictMode instanceof Boolean) {
+                    JSONAssert.assertNotEquals(message, (JSONArray) expected, (JSONArray) actual, (Boolean) strictMode);
+                } else {
+                    fail(strictModeMessage);
+                }
+                assertEqualsFailed = false;
+                fail(testShouldFailMessage); //will throw AssertionError
+            } catch (AssertionError ae) {
+                handleAssertionError(message, assertEqualsFailed, ae);
+            }
+        } else if(expected instanceof String && actual instanceof String) {
+            try {
+                if(strictMode instanceof JSONCompareMode) {
+                    JSONAssert.assertNotEquals(message, (String) expected, (String) actual, (JSONCompareMode) strictMode);
+                } else if(strictMode instanceof Boolean) {
+                    JSONAssert.assertNotEquals(message, (String) expected, (String) actual, (Boolean) strictMode);
+                } else {
+                    fail(strictModeMessage);
+                }
+                assertEqualsFailed = false;
+                fail(testShouldFailMessage); //will throw AssertionError
+            } catch (AssertionError ae) {
+                handleAssertionError(message, assertEqualsFailed, ae);
+            }
+        } else if(expected instanceof String && actual instanceof JSONObject) {
+            try {
+                if(strictMode instanceof JSONCompareMode) {
+                    JSONAssert.assertNotEquals(message, (String) expected, (JSONObject) actual, (JSONCompareMode) strictMode);
+                } else if(strictMode instanceof Boolean) {
+                    JSONAssert.assertNotEquals(message, (String) expected, (JSONObject) actual, (Boolean) strictMode);
+                } else {
+                    fail(strictModeMessage);
+                }
+                assertEqualsFailed = false;
+                fail(testShouldFailMessage); //will throw AssertionError
+            } catch (AssertionError ae) {
+                handleAssertionError(message, assertEqualsFailed, ae);
+            }
+        } else if(expected instanceof JSONObject && actual instanceof JSONObject) {
+            try {
+                if(strictMode instanceof JSONCompareMode) {
+                    JSONAssert.assertNotEquals(message, (JSONObject) expected, (JSONObject) actual, (JSONCompareMode) strictMode);
+                } else if(strictMode instanceof Boolean) {
+                    JSONAssert.assertNotEquals(message, (JSONObject) expected, (JSONObject) actual, (Boolean) strictMode);
                 } else {
                     fail(strictModeMessage);
                 }


### PR DESCRIPTION
- Overloaded equals() ans notEquals() methods to accept a message
- Junits for all the possible new overloads
- improvements in some of the existing junits