### PR TITLE
Added a MANIFEST.MF file so that the jar can be used directly in OSGi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/.classpath
+/.project
+/build.properties

--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,0 +1,2 @@
+/org.eclipse.core.resources.prefs
+/org.eclipse.jdt.core.prefs

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: JSONassert
+Bundle-SymbolicName: org.skyscreamer.jsonassert
+Bundle-Version: 1.5.1.v20170627
+Export-Package: org.skyscreamer.jsonassert,
+ org.skyscreamer.jsonassert.comparator
+Require-Bundle: org.junit
+Import-Package: org.json

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -64,6 +65,18 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Built-By>${user.name}</Built-By>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Added a MANIFEST.MF file so that the jar (built in the usual way with maven) can be used directly in OSGi - so for example you can use it as an eclipse bundle dependency in your target platform for running junit tests.

Also added some gitignore entries to not pollute the repo. with eclipse project specific files but still be able to use it in eclipse.