### PR TITLE
Compare between values exceeded long range and double precision.

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/comparator/DefaultComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/DefaultComparator.java
@@ -57,6 +57,11 @@ public class DefaultComparator extends AbstractComparator {
             result.fail(prefix, expectedValue, actualValue);
         }
         if (areNumbers(expectedValue, actualValue)) {
+            if(expectedValue instanceof Long && actualValue instanceof Long){
+                if (areNotSameLongs(expectedValue, actualValue)) {
+                    result.fail(prefix, expectedValue, actualValue);
+                }
+            }
             if (areNotSameDoubles(expectedValue, actualValue)) {
                 result.fail(prefix, expectedValue, actualValue);
             }
@@ -101,5 +106,15 @@ public class DefaultComparator extends AbstractComparator {
 
     protected boolean areNotSameDoubles(Object expectedValue, Object actualValue) {
         return ((Number) expectedValue).doubleValue() != ((Number) actualValue).doubleValue();
+    }
+    /**
+     * Compares JSON object provided to the expected JSON object using provided comparator, and returns the results of
+     * the comparison.
+     * @param expectedValue expected long value
+     * @param actualValue actual long value
+     * @return result of the comparison
+     */
+    protected boolean areNotSameLongs(Object expectedValue, Object actualValue) {
+        return ((Number) expectedValue).longValue() != ((Number) actualValue).longValue();
     }
 }

--- a/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
@@ -286,6 +286,21 @@ public class JSONAssertTest {
         JSONAssert.assertEquals(expected, actual, true);
         JSONAssert.assertEquals(actual, expected, true);
     }
+    @Test
+    public void exceedDouble() throws JSONException {
+        JSONAssert.assertNotEquals("{ \"value\": 1234567890.1234567890123456 }", "{ \"value\": 1234567890.1234567000000000 }", true);
+    }
+    @Test
+    public void notExceedLong() throws JSONException {
+        JSONAssert.assertEquals("{ \"value\": 1234567890123423 }", "{ \"value\": 1234567890123423 }", true);
+        JSONAssert.assertNotEquals("{ \"value\": 1234567890123243233}", "{ \"value\": 1234567890123243232 }", true);
+    }
+
+    @Test
+    public void exceedLong() throws JSONException {
+        JSONAssert.assertNotEquals("{ \"value\": 12345678901234567890123456 }", "{ \"value\": 12345678901234567800000000}", true);
+        JSONAssert.assertEquals("{ \"value\": 12345678901234567890123456 }", "{ \"value\": 12345678901234567890123456}", true);
+    }
 
     @Test
     public void testEquivalentIntAndDouble() throws JSONException {


### PR DESCRIPTION
This bug in #107 is mainly due to the fact that an integer larger than long range will be parsed as a `double `when parsed by `JSON `library. The simplest way is change the value to string format and then compare the Strings.