### PR TITLE
Improve comparison between JSON objects in array format

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/comparator/AbstractComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/AbstractComparator.java
@@ -89,16 +89,57 @@ public abstract class AbstractComparator implements JSONComparator {
         Map<Object, JSONObject> expectedValueMap = arrayOfJsonObjectToMap(expected, uniqueKey);
         Map<Object, JSONObject> actualValueMap = arrayOfJsonObjectToMap(actual, uniqueKey);
         for (Object id : expectedValueMap.keySet()) {
-            if (!actualValueMap.containsKey(id)) {
+            boolean same = false;
+            Object aid = null;
+            for(Object id2 : actualValueMap.keySet()){
+                String sid = id.toString();
+                String sid2 = id2.toString();
+                if(sid.indexOf(".") > 0){
+                    sid = sid.replaceAll("0+?$", "");
+                    sid = sid.replaceAll("[.]$", "");
+                }
+                if(sid2.indexOf(".") > 0){
+                    sid2 = sid2.replaceAll("0+?$", "");
+                    sid2 = sid2.replaceAll("[.]$", "");
+                }
+                if(sid.equals(sid2)){
+                    same = true;
+                    aid = id2;
+
+                }
+            }
+            if (!actualValueMap.containsKey(id)&&!same) {
                 result.missing(formatUniqueKey(key, uniqueKey, id), expectedValueMap.get(id));
                 continue;
             }
             JSONObject expectedValue = expectedValueMap.get(id);
-            JSONObject actualValue = actualValueMap.get(id);
+            JSONObject actualValue = null;
+            if(!same) {
+                actualValue = actualValueMap.get(id);
+            }
+            else{
+                actualValue = actualValueMap.get(aid);
+            }
             compareValues(formatUniqueKey(key, uniqueKey, id), expectedValue, actualValue, result);
         }
         for (Object id : actualValueMap.keySet()) {
-            if (!expectedValueMap.containsKey(id)) {
+            boolean same = false;
+            for(Object id2 : expectedValueMap.keySet()){
+                String sid = id.toString();
+                String sid2 = id2.toString();
+                if(sid.indexOf(".") > 0){
+                    sid = sid.replaceAll("0+?$", "");
+                    sid = sid.replaceAll("[.]$", "");
+                }
+                if(sid2.indexOf(".") > 0){
+                    sid2 = sid2.replaceAll("0+?$", "");
+                    sid2 = sid2.replaceAll("[.]$", "");
+                }
+                if(sid.equals(sid2)){
+                    same = true;
+                }
+            }
+            if (!expectedValueMap.containsKey(id)&&!same) {
                 result.unexpected(formatUniqueKey(key, uniqueKey, id), actualValueMap.get(id));
             }
         }

--- a/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
@@ -390,6 +390,34 @@ public class JSONAssertTest {
     }
     
     @Test
+    public void testArrayCompareDifferingPrecision() throws JSONException {
+        String actual =   "[ { \"Foo\" : 1 }]";
+        String expected = "[{ \"Foo\" : 1.0  }]";
+        JSONAssert.assertEquals(expected, actual, false);
+    }
+
+    @Test
+    public void testArrayCompareSamePrecision() throws JSONException {
+        String actual =   "[{ \"Foo\" : 1   }]";
+        String expected = "[{ \"Foo\" : 1   }]";
+        JSONAssert.assertEquals(expected, actual, false);
+    }
+
+    @Test
+    public void testObjectCompareDifferingPrecision() throws JSONException {
+        String actual =   "{ \"Foo\" : 1.0 }";
+        String expected = "{ \"Foo\" : 1   }";
+        JSONAssert.assertEquals(expected, actual, false);
+    }
+
+    @Test
+    public void testObjectCompareSamePrecision() throws JSONException {
+        String actual =   "{ \"Foo\" : 1   }";
+        String expected = "{ \"Foo\" : 1   }";
+        JSONAssert.assertEquals(expected, actual, false);
+    }
+
+    @Test
     public void testAssertEqualsStringJSONArrayBooleanWithMessage() throws JSONException {
         JSONArray actual = new JSONArray(Arrays.asList(1, 2, 3));
         JSONAssert.assertEquals("Message", "[1,2,3]", actual, false);


### PR DESCRIPTION
I solved the problem in #115  that using number as the unique key to compare **json object** which is  in **array** format. The numbers are the same but in different precision. So when I check if the numbers are the same. I truncated the zeros behind the numbers and compare them in **String** format. 
```java
sid = sid.replaceAll("0+?$", "");
```