### PR TITLE
Improve detection for some invalid JSON

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/JSONParser.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONParser.java
@@ -39,19 +39,29 @@ public class JSONParser {
      * @throws JSONException JSON parsing error
      */
     public static Object parseJSON(final String s) throws JSONException {
-        if (s.trim().startsWith("{")) {
+        if (s.trim().startsWith("{")&&s.trim().endsWith("}")) {
             return new JSONObject(s);
         }
-        else if (s.trim().startsWith("[")) {
+        else if (s.trim().startsWith("[")&&s.trim().endsWith("]")) {
             return new JSONArray(s);
-        } else if (s.trim().startsWith("\"")
+        } else if (s.trim().startsWith("\"") && s.trim().endsWith("\"")
                    || s.trim().matches(NUMBER_REGEX)) {
-          return new JSONString() {
-            @Override
-            public String toJSONString() {
-              return s;
+            int pos = 0;
+            boolean hascolon = false;
+            while(pos<s.length()){
+                if(s.charAt(pos)==':'){
+                    hascolon = true;
+                }
+                pos++;
             }
-          };
+            if(!hascolon){
+                return new JSONString() {
+                  @Override
+                  public String toJSONString() {
+                    return s;
+                }
+                };
+            }
         }
         throw new JSONException("Unparsable JSON string: " + s);
     }

--- a/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
@@ -640,6 +640,27 @@ public class JSONAssertTest {
                 new RegularExpressionValueMatcher<Object>("\\d"))
         ));
     }
+
+    @Test(expected= JSONException.class)
+    public void testInvalidString() throws JSONException {
+        JSONAssert.assertEquals("   \"id\": 1,\"props\": [{\"id\": 1,\"propB\": true}, ],\"propC\": false}  ",
+                "{id:\"12345\"}", false);
+    }
+
+    @Test(expected= JSONException.class)
+    public void testInvalidJsonObject() throws JSONException {
+        JSONCompare.compareJSON("{}a", "{}", JSONCompareMode.STRICT);
+    }
+
+    @Test(expected= JSONException.class)
+    public void testInvalidJsonArray() throws JSONException {
+        JSONCompare.compareJSON("[]", "[]a", JSONCompareMode.STRICT);
+    }
+
+    @Test(expected= JSONException.class)
+    public void testInvalidComplexJsonArray() throws JSONException {
+        JSONCompare.compareJSON("[{'a': 'b'}a]", "[{'a': 'b'}]", JSONCompareMode.STRICT);
+    }
     
     private void testPass(String expected, String actual, JSONCompareMode compareMode)
             throws JSONException


### PR DESCRIPTION
I found that some invalid JSON will be parsed as valid when they are in some situations. Also mentioned in #127 
* the beginning character is "\"", but it should be "[" or "{" .
* the beginning character is "[" , but the end char is not "]".
* the beginning character is "[" , but the end char is not "]".
The json lib will parsed the input string only check the first char. So this invalid json will be parsed. So i also check the end of the json. And when there is ":" in the string. It shouldn't be seen as a JSONString.