### PR TITLE
Included expected and actual in error message when arrays are not the same size #108

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/comparator/DefaultComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/DefaultComparator.java
@@ -77,7 +77,8 @@ public class DefaultComparator extends AbstractComparator {
     public void compareJSONArray(String prefix, JSONArray expected, JSONArray actual, JSONCompareResult result)
             throws JSONException {
         if (expected.length() != actual.length()) {
-            result.fail(prefix + "[]: Expected " + expected.length() + " values but got " + actual.length());
+            result.fail(prefix + "[]: Expected " + expected.length() + " values but got " + actual.length() + ", "
+                    + "Expected: " + expected + ", " + "Actual: " + actual);
             return;
         } else if (expected.length() == 0) {
             return; // Nothing to compare

--- a/src/test/java/org/skyscreamer/jsonassert/JSONCompareTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONCompareTest.java
@@ -40,7 +40,7 @@ public class JSONCompareTest {
     @Test
     public void reportsArraysOfUnequalLength() throws JSONException {
         JSONCompareResult result = compareJSON("[4]", "[]", LENIENT);
-        assertThat(result, failsWithMessage(equalTo("[]: Expected 1 values but got 0")));
+        assertThat(result, failsWithMessage(equalTo("[]: Expected 1 values but got 0, Expected: [4], Actual: []")));
     }
 
     @Test


### PR DESCRIPTION
Intended to fix the issue in #108. 
