### PR TITLE
Ensure full array comparison test ignores order

### DIFF
--- a/src/test/java/org/skyscreamer/jsonassert/comparator/CustomComparatorTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/comparator/CustomComparatorTest.java
@@ -48,6 +48,6 @@ public class CustomComparatorTest {
 
         Assert.assertTrue(compareResult.failed());
         String message = compareResult.getMessage().replaceAll("\n", "");
-        Assert.assertTrue(message, message.matches(".*id=5.*Expected.*id=6.*Unexpected.*id=7.*Unexpected.*"));
+        Assert.assertTrue(message, message.matches("(?:.*id=(?:5.*Expected|6.*Unexpected|7.*Unexpected)){3}.*"));
     }
 }


### PR DESCRIPTION
This test was failing under [NonDex](https://github.com/TestingResearchIllinois/NonDex) because it relied on a specific order of comparison results; this PR alters it to accept any order of the results so long as all the expected ones are present.  (As a bonus, the regex now looks a bit cleaner.)