### PR TITLE
Fixed #130 assertEquals(...) may throw NullPointerException when given invalid JSON string.

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/JSONCompareResult.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONCompareResult.java
@@ -245,6 +245,9 @@ public class JSONCompareResult {
         } else if (value instanceof JSONObject) {
             return "a JSON object";
         } else {
+            if (value == null) {
+                return "null";
+            }
             return value.toString();
         }
     }

--- a/src/main/java/org/skyscreamer/jsonassert/JSONParser.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONParser.java
@@ -39,19 +39,29 @@ public class JSONParser {
      * @throws JSONException JSON parsing error
      */
     public static Object parseJSON(final String s) throws JSONException {
-        if (s.trim().startsWith("{")) {
+        if (s.trim().startsWith("{")&&s.trim().endsWith("}")) {
             return new JSONObject(s);
         }
-        else if (s.trim().startsWith("[")) {
+        else if (s.trim().startsWith("[")&&s.trim().endsWith("]")) {
             return new JSONArray(s);
-        } else if (s.trim().startsWith("\"")
-                   || s.trim().matches(NUMBER_REGEX)) {
-          return new JSONString() {
-            @Override
-            public String toJSONString() {
-              return s;
+        } else if (s.trim().startsWith("\"") && s.trim().endsWith("\"")
+                || s.trim().matches(NUMBER_REGEX)) {
+            int pos = 0;
+            boolean hascolon = false;
+            while(pos<s.length()){
+                if(s.charAt(pos)==':'){
+                    hascolon = true;
+                }
+                pos++;
             }
-          };
+            if(!hascolon){
+                return new JSONString() {
+                    @Override
+                    public String toJSONString() {
+                        return s;
+                    }
+                };
+            }
         }
         throw new JSONException("Unparsable JSON string: " + s);
     }

--- a/src/main/java/org/skyscreamer/jsonassert/comparator/DefaultComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/DefaultComparator.java
@@ -55,6 +55,7 @@ public class DefaultComparator extends AbstractComparator {
         }
         if ((expectedValue == null && actualValue != null) || (expectedValue != null && actualValue == null)) {
             result.fail(prefix, expectedValue, actualValue);
+            return;
         }
         if (areNumbers(expectedValue, actualValue)) {
             if (areNotSameDoubles(expectedValue, actualValue)) {

--- a/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
@@ -640,7 +640,24 @@ public class JSONAssertTest {
                 new RegularExpressionValueMatcher<Object>("\\d"))
         ));
     }
-    
+    @Test
+    public void testAssertWithNullValues1() throws JSONException {
+        performAssertEqualsTestForMessageVerification("[{id:1},]", "[{id:1},{}]", true);
+    }
+
+    @Test
+    public void testAssertWithNullValues2() throws JSONException {
+        JSONAssert.assertNotEquals("[{id:1},]", "[{id:2},]", true);
+    }
+    @Test
+    public void testAssertWithNullValues3() throws JSONException {
+        JSONAssert.assertEquals("[{id:1},]" , "[{id:1},]" , true);
+    }
+    @Test
+    public void testAssertWithNullValues4() throws JSONException {
+        performAssertEqualsTestForMessageVerification("[{id:1},{id:2},]", "[{id:1},{id:2},{}]", true);
+    }
+
     private void testPass(String expected, String actual, JSONCompareMode compareMode)
             throws JSONException
     {

--- a/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONAssertTest.java
@@ -658,6 +658,11 @@ public class JSONAssertTest {
         performAssertEqualsTestForMessageVerification("[{id:1},{id:2},]", "[{id:1},{id:2},{}]", true);
     }
 
+    @Test
+    public void testAssertWithNullValues5() throws JSONException {
+        JSONAssert.assertEquals("[{id:1},{id:2},]" , "[{id:1},{id:2},]" , true);
+    }
+
     private void testPass(String expected, String actual, JSONCompareMode compareMode)
             throws JSONException
     {


### PR DESCRIPTION
Fixed #130 