### PR TITLE
Fixed issue where CustomComparator is ignored when matching certain r…

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/comparator/AbstractComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/AbstractComparator.java
@@ -43,6 +43,12 @@ public abstract class AbstractComparator implements JSONComparator {
         return result;
     }
 
+    public final JSONCompareResult compareJSONPreserveContext(String prefix, JSONObject expected, JSONObject actual) throws JSONException{
+        JSONCompareResult result = new JSONCompareResult();
+        compareJSON(prefix, expected, actual, result);
+        return result;
+    }
+
     /**
      * Compares JSONArray provided to the expected JSONArray, and returns the results of the comparison.
      *
@@ -54,6 +60,12 @@ public abstract class AbstractComparator implements JSONComparator {
     public final JSONCompareResult compareJSON(JSONArray expected, JSONArray actual) throws JSONException {
         JSONCompareResult result = new JSONCompareResult();
         compareJSONArray("", expected, actual, result);
+        return result;
+    }
+
+    public final JSONCompareResult compareJSONPreserveContext(String prefix, JSONArray expected, JSONArray actual) throws JSONException{
+        JSONCompareResult result = new JSONCompareResult();
+        compareJSONArray(prefix, expected, actual, result);
         return result;
     }
 
@@ -153,13 +165,13 @@ public abstract class AbstractComparator implements JSONComparator {
                     continue;
                 }
                 if (expectedElement instanceof JSONObject) {
-                    if (compareJSON((JSONObject) expectedElement, (JSONObject) actualElement).passed()) {
+                    if (compareJSONPreserveContext(key + "[" + i + "]",(JSONObject) expectedElement, (JSONObject) actualElement).passed()) {
                         matched.add(j);
                         matchFound = true;
                         break;
                     }
                 } else if (expectedElement instanceof JSONArray) {
-                    if (compareJSON((JSONArray) expectedElement, (JSONArray) actualElement).passed()) {
+                    if (compareJSONPreserveContext(key + "[" + i + "]", (JSONArray) expectedElement, (JSONArray) actualElement).passed()) {
                         matched.add(j);
                         matchFound = true;
                         break;

--- a/src/test/java/org/skyscreamer/jsonassert/JSONCustomComparatorTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONCustomComparatorTest.java
@@ -21,6 +21,7 @@ import org.skyscreamer.jsonassert.comparator.JSONComparator;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.skyscreamer.jsonassert.JSONCompare.compareJSON;
 
 public class JSONCustomComparatorTest {
@@ -118,6 +119,15 @@ public class JSONCustomComparatorTest {
             "  }\n" +
             "}";
 
+    String rootDeepWildcardWithArray = "{\n" +
+            "  \"addresses\": [{\n" +
+            "    \"address\": {\n" +
+            "      \"num\": \"not_a_number\"" +
+            "    }\n" +
+            "  }]\n" +
+            "}";
+
+
     int comparatorCallCount = 0;
     ValueMatcher<Object> comparator = new ValueMatcher<Object>() {
         @Override
@@ -165,5 +175,17 @@ public class JSONCustomComparatorTest {
         JSONCompareResult result = compareJSON(rootDeepWildcardExpected, rootDeepWildcardActual, jsonCmp);
         assertTrue(result.getMessage(), result.passed());
         assertEquals(4, comparatorCallCount);
+    }
+
+    @Test
+    public void whenRootDeepWildcardPathWithArrayMatchesCallCustomMatcher() throws JSONException {
+        JSONComparator jsonCmpStrict        = new CustomComparator(JSONCompareMode.STRICT,         new Customization("addresses[*].address.num", new RegularExpressionValueMatcher<Object>("\\d")));
+        JSONComparator jsonCmpNonExtensible = new CustomComparator(JSONCompareMode.NON_EXTENSIBLE, new Customization("addresses[*].address.num", new RegularExpressionValueMatcher<Object>("\\d")));
+
+        JSONCompareResult resultStrict = compareJSON(rootDeepWildcardWithArray, rootDeepWildcardWithArray, jsonCmpStrict);
+        assertFalse(resultStrict.getMessage(), resultStrict.passed());
+
+        JSONCompareResult resultNonExtensible = compareJSON(rootDeepWildcardWithArray, rootDeepWildcardWithArray, jsonCmpNonExtensible);
+        assertFalse(resultNonExtensible.getMessage(), resultNonExtensible.passed());
     }
 }

--- a/src/test/java/org/skyscreamer/jsonassert/JSONCustomComparatorTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONCustomComparatorTest.java
@@ -181,11 +181,15 @@ public class JSONCustomComparatorTest {
     public void whenRootDeepWildcardPathWithArrayMatchesCallCustomMatcher() throws JSONException {
         JSONComparator jsonCmpStrict        = new CustomComparator(JSONCompareMode.STRICT,         new Customization("addresses[*].address.num", new RegularExpressionValueMatcher<Object>("\\d")));
         JSONComparator jsonCmpNonExtensible = new CustomComparator(JSONCompareMode.NON_EXTENSIBLE, new Customization("addresses[*].address.num", new RegularExpressionValueMatcher<Object>("\\d")));
+        JSONComparator jsonCmpNonLenient = new CustomComparator(JSONCompareMode.NON_EXTENSIBLE, new Customization("addresses[*].address.num", new RegularExpressionValueMatcher<Object>("\\d")));
 
         JSONCompareResult resultStrict = compareJSON(rootDeepWildcardWithArray, rootDeepWildcardWithArray, jsonCmpStrict);
         assertFalse(resultStrict.getMessage(), resultStrict.passed());
 
         JSONCompareResult resultNonExtensible = compareJSON(rootDeepWildcardWithArray, rootDeepWildcardWithArray, jsonCmpNonExtensible);
         assertFalse(resultNonExtensible.getMessage(), resultNonExtensible.passed());
+
+        JSONCompareResult resultLenient = compareJSON(rootDeepWildcardWithArray, rootDeepWildcardWithArray, jsonCmpNonExtensible);
+        assertFalse(resultLenient.getMessage(), resultLenient.passed());
     }
 }


### PR DESCRIPTION
…egular expressions that traverse JSON arrays

This issue only occurs when using the NON_EXTENSIBLE or LENIENT modes.