### PR TITLE
Move JSONString out of split package

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/JSONCompare.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONCompare.java
@@ -17,7 +17,6 @@ package org.skyscreamer.jsonassert;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.json.JSONString;
 import org.skyscreamer.jsonassert.comparator.DefaultComparator;
 import org.skyscreamer.jsonassert.comparator.JSONComparator;
 
@@ -95,7 +94,7 @@ public final class JSONCompare {
 
     /**
      * Compares {@link JSONString} provided to the expected {@code JSONString}, checking that the
-     * {@link org.json.JSONString#toJSONString()} are equal.
+     * {@link JSONString#toJSONString()} are equal.
      *
      * @param expected Expected {@code JSONstring}
      * @param actual   {@code JSONstring} to compare

--- a/src/main/java/org/skyscreamer/jsonassert/JSONParser.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONParser.java
@@ -17,7 +17,6 @@ package org.skyscreamer.jsonassert;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.json.JSONString;
 
 /**
  * Simple JSON parsing utility.

--- a/src/main/java/org/skyscreamer/jsonassert/JSONString.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONString.java
@@ -12,7 +12,7 @@
  * limitations under the License.
 */
 
-package org.json;
+package org.skyscreamer.jsonassert;
 
 /**
  * The JSONString interface allows a toJSONString() method so that a class can change


### PR DESCRIPTION
This removes the `org.json` package as it's a split package with the one in `android-json`, fixing usages in the module system introduced in Java 9.

`JSONString` has been moved to `org.skyscreamer.jsonassert`. As far as I can tell, the reason this was in a split package to begin with is to allow `JSONString` implementers to have access to package-private methods in `android-json`'s `org.json`.

The package-private methods/fields are:
* `JSONStringer`
  * `JSONStringer(int indentSpaces)`
  * `JSONStringer open(Scope empty, String openBracket)`
  * `JSONStringer close(Scope empty, Scope nonempty, String closeBracket)`
  * `final StringBuilder out`
  * `enum Scope`
* `JSON`
  * `static double checkDouble(double d)`
  * `static Boolean toBoolean(Object value)`
  * `static Double toDouble(Object value)`
  * `static Integer toInteger(Object value)`
  * `static Long toLong(Object value)`
  * `static String toString(Object value)`
* `JSONObject`
  * `String checkName(String name)`
  * `void writeTo(JSONStringer stringer)`
* `JSONArray`
  * `void writeTo(JSONStringer stringer)`

So if you wanted to create your own "JSONThing", these methods are clearly pretty useful. I don't know how common it is to do this, but I imagine most consumers are just using `JSONAssert`, like [Spring does](https://github.com/spring-projects/spring-framework/blob/main/spring-test/src/main/java/org/springframework/test/util/JsonExpectationsHelper.java). I'd argue that anyone using these package-private methods is skilled enough to just make them accessible via reflection, so while this is a breaking change, I don't think it's that bad.

Given it is a breaking change however, maybe this PR can be targeted to a 2.0 release? I'm not sure how committed you are to semantic versioning, but I'm pretty indifferent as long as this gets merged :). Thanks!