### PR TITLE
Issue #109 unique key for an arrays of json objects

### DIFF
--- a/src/main/java/org/skyscreamer/jsonassert/Customization.java
+++ b/src/main/java/org/skyscreamer/jsonassert/Customization.java
@@ -22,12 +22,23 @@ import java.util.regex.Pattern;
 public final class Customization {
 	private final Pattern path;
 	private final ValueMatcher<Object> comparator;
+	private String arrayUniqueKey;
 
 	public Customization(String path, ValueMatcher<Object> comparator) {
         assert path != null;
         assert comparator != null;
 		this.path = Pattern.compile(buildPattern(path));
 		this.comparator = comparator;
+	}
+	public Customization(String path, String arrayUniqueKey) {
+		assert path != null;
+		this.path = Pattern.compile(buildPattern(path));
+		this.comparator = null;
+		this.arrayUniqueKey=arrayUniqueKey;
+	}
+
+	public String getArrayUniqueKey() {
+		return arrayUniqueKey;
 	}
 
 	private String buildPattern(String path) {

--- a/src/main/java/org/skyscreamer/jsonassert/comparator/AbstractComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/AbstractComparator.java
@@ -81,6 +81,15 @@ public abstract class AbstractComparator implements JSONComparator {
 
     protected void compareJSONArrayOfJsonObjects(String key, JSONArray expected, JSONArray actual, JSONCompareResult result) throws JSONException {
         String uniqueKey = findUniqueKey(expected);
+        doCompareJSONArrayOfJsonObjects(key, expected, actual, result, uniqueKey);
+    }
+
+    protected void compareJSONArrayOfJsonObjects(String key, JSONArray expected, JSONArray actual, JSONCompareResult result, String uniqueKey) throws JSONException {
+        doCompareJSONArrayOfJsonObjects(key, expected, actual, result, uniqueKey);
+    }
+
+    private void doCompareJSONArrayOfJsonObjects(String key, JSONArray expected, JSONArray actual,
+        JSONCompareResult result, String uniqueKey) throws JSONException {
         if (uniqueKey == null || !isUsableAsUniqueKey(uniqueKey, actual)) {
             // An expensive last resort
             recursivelyCompareJSONArray(key, expected, actual, result);
@@ -103,7 +112,6 @@ public abstract class AbstractComparator implements JSONComparator {
             }
         }
     }
-
     protected void compareJSONArrayOfSimpleValues(String key, JSONArray expected, JSONArray actual, JSONCompareResult result) throws JSONException {
         Map<Object, Integer> expectedCount = JSONCompareUtil.getCardinalityMap(jsonArrayToList(expected));
         Map<Object, Integer> actualCount = JSONCompareUtil.getCardinalityMap(jsonArrayToList(actual));

--- a/src/main/java/org/skyscreamer/jsonassert/comparator/CustomComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/CustomComparator.java
@@ -14,6 +14,7 @@
 
 package org.skyscreamer.jsonassert.comparator;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.skyscreamer.jsonassert.Customization;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -35,7 +36,7 @@ public class CustomComparator extends DefaultComparator {
     @Override
     public void compareValues(String prefix, Object expectedValue, Object actualValue, JSONCompareResult result) throws JSONException {
         Customization customization = getCustomization(prefix);
-        if (customization != null) {
+        if (customization != null && customization.getArrayUniqueKey() == null) {
             try {
     	        if (!customization.matches(prefix, actualValue, expectedValue, result)) {
                     result.fail(prefix, expectedValue, actualValue);
@@ -45,7 +46,12 @@ public class CustomComparator extends DefaultComparator {
                 result.fail(prefix, e);
             }
         } else {
-            super.compareValues(prefix, expectedValue, actualValue, result);
+            String arrayUniqueKey = customization == null ? null : customization.getArrayUniqueKey();
+            if (expectedValue instanceof JSONArray && arrayUniqueKey != null) {
+                compareJSONArrayOfJsonObjects(prefix, (JSONArray) expectedValue, (JSONArray) actualValue, result, arrayUniqueKey);
+            } else {
+                super.compareValues(prefix, expectedValue, actualValue, result);
+            }
         }
     }
 

--- a/src/test/java/org/skyscreamer/jsonassert/JSONArrayObjectsTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONArrayObjectsTest.java
@@ -1,0 +1,64 @@
+package org.skyscreamer.jsonassert;
+
+
+import java.util.UUID;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
+
+public class JSONArrayObjectsTest {
+
+  public static final UUID RANDOM_ID_1 = UUID.randomUUID();
+  public static final UUID RANDOM_ID_2 = UUID.randomUUID();
+  public static final String ARRAY_NAME = "arrayName";
+  public static final String ID = "id";
+  public static final String DATE = "date";
+
+  @Test
+  public void testJsonArrayWithIgnoredFieldAndProvidedIdField() throws JSONException {
+
+    JSONArray jsonArray1 = getJsonArray(RANDOM_ID_1, RANDOM_ID_2);
+    JSONArray jsonArray2 = getJsonArray(RANDOM_ID_2, RANDOM_ID_1);
+
+    JSONObject jsonObject1 = new JSONObject();
+    jsonObject1.put(ARRAY_NAME, jsonArray1);
+
+    JSONObject jsonObject2 = new JSONObject();
+    jsonObject2.put(ARRAY_NAME, jsonArray2);
+
+    CustomComparator customComparator = new CustomComparator(
+        JSONCompareMode.LENIENT,
+        new Customization("**." + DATE, getDummyMatcher()), //ignoring this field
+        new Customization(ARRAY_NAME, ID)
+    );
+
+    JSONAssert.assertEquals(jsonObject1, jsonObject2, customComparator);
+  }
+
+  private static ValueMatcher<Object> getDummyMatcher() {
+    return new ValueMatcher<Object>() {
+      @Override
+      public boolean equal(Object o1, Object o2) {
+        return true;
+      }
+    };
+  }
+
+  private static JSONArray getJsonArray(UUID randomId2, UUID randomId1) throws JSONException {
+    JSONArray jsonArray1 = new JSONArray();
+
+    JSONObject jsonObject1 = new JSONObject();
+    jsonObject1.put(ID, randomId2);
+    jsonObject1.put(DATE, UUID.randomUUID());
+
+    JSONObject jsonObject2 = new JSONObject();
+    jsonObject2.put(ID, randomId1);
+    jsonObject2.put(DATE, UUID.randomUUID());
+
+    jsonArray1.put(jsonObject1);
+    jsonArray1.put(jsonObject2);
+    return jsonArray1;
+  }
+}


### PR DESCRIPTION
I also had the same problem, as people in [issue#109](https://github.com/skyscreamer/JSONassert/issues/109). 
For example with json like this:

```
{
    "bookings": [
        {
            "booking_id": "1d7a81b0-e0c4-441d-9fe4-48dfb776d8e7", 
            "created_at": "2023-09-07T07:28:57.822Z"
        },
           {
            "booking_id": "2a6a97b0-e0c4-441d-9fe4-48dfb776f1a8", 
            "created_at": "2023-09-07T08:28:55.823Z"
        }
    ]
}
```

AbstractComparator makes decision to use "created_at" as a unique key, so assertion fails. I fixed it, making it possible to pass unique key name as a parameter.