### PR TITLE
Revert to Java 8 to maximize usability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>jsonassert</artifactId>
-    <version>1.5.2</version>
+    <version>1.5.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JSONassert</name>
@@ -12,7 +12,7 @@
     <url>https://github.com/skyscreamer/JSONassert</url>
 
     <properties>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <licenses>


### PR DESCRIPTION
To close #190 

Please release 1.5.3 to make dependabot, renovate (and others) correctly update this library version in the hundreds of projects using it.