### PR TITLE
Implement full JSONPath Customisation support via Jayway JsonPath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
             <version>20240303</version>
         </dependency>
         <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.9.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>

--- a/src/main/java/org/skyscreamer/jsonassert/Customization.java
+++ b/src/main/java/org/skyscreamer/jsonassert/Customization.java
@@ -143,9 +143,6 @@ public final class Customization {
 	 */
 	public boolean matches(String prefix, Object actual, Object expected,
 			JSONCompareResult result) throws ValueMatcherException {
-		if (comparator instanceof LocationAwareValueMatcher) {
-			return ((LocationAwareValueMatcher<Object>)comparator).equal(prefix, actual, expected, result);
-		}
-		return comparator.equal(actual, expected);
+		return CustomizationEvaluator.matches(comparator, prefix, actual, expected, result);
 	}
 }

--- a/src/main/java/org/skyscreamer/jsonassert/CustomizationEvaluator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/CustomizationEvaluator.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.skyscreamer.jsonassert;
+
+final class CustomizationEvaluator {
+    private CustomizationEvaluator() {}
+
+    /**
+     * Return true if actual value matches expected value using this
+     * Customization's comparator. The equal method used for comparison depends
+     * on type of comparator.
+     *
+     * @param comparator Comparator to use while comparing JSON items
+     *
+     * @param prefix
+     *            JSON path of the JSON item being tested (only used if
+     *            comparator is a LocationAwareValueMatcher)
+     * @param actual
+     *            JSON value being tested
+     * @param expected
+     *            expected JSON value
+     * @param result
+     *            JSONCompareResult to which match failure may be passed (only
+     *            used if comparator is a LocationAwareValueMatcher)
+     * @return true if expected and actual equal or any difference has already
+     *         been passed to specified result instance, false otherwise.
+     * @throws ValueMatcherException
+     *             if expected and actual values not equal and ValueMatcher
+     *             needs to override default comparison failure message that
+     *             would be generated if this method returned false.
+     */
+    public static boolean matches(ValueMatcher<Object> comparator, String prefix, Object actual, Object expected,
+                           JSONCompareResult result) throws ValueMatcherException {
+        if (comparator instanceof LocationAwareValueMatcher) {
+            return ((LocationAwareValueMatcher<Object>)comparator).equal(prefix, actual, expected, result);
+        }
+        return comparator.equal(actual, expected);
+    }
+}

--- a/src/main/java/org/skyscreamer/jsonassert/JSONPathCustomization.java
+++ b/src/main/java/org/skyscreamer/jsonassert/JSONPathCustomization.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.skyscreamer.jsonassert;
+
+import com.jayway.jsonpath.JsonPath;
+
+/**
+ * Specifies a <a href="https://goessner.net/articles/JsonPath/">JSONPath</a>-based customisation.
+ * <br><br>
+ * For supported queries, refer to:
+ * <ul>
+ *     <li><a href="https://github.com/json-path/JsonPath">Documentation</a> of the <b>Jayway JsonPath project</b></li>
+ *     <li><a href="https://goessner.net/articles/JsonPath/">Documentation</a> of the <b>original Stefan Goessner JsonPath implementation</b></li>
+ * </ul>
+ *
+ * @author Shane B. (<a href="mailto:shane@wander.dev">shane@wander.dev</a>)
+ */
+public class JSONPathCustomization {
+    private static final ValueMatcher<Object> IGNORE_FIELD = (expected, actual) -> true;
+
+    private final JsonPath jsonPath;
+    private final ValueMatcher<Object> comparator;
+
+    /**
+     * Defines a JSONAssert customisation.
+     * <br>
+     * For all fields that match the specified path,
+     * the defined custom comparator {@link ValueMatcher} will be evaluated in place of comparing exactly
+     * to the <code>expected</code> JSON.
+     * @param jsonPath      <a href="https://goessner.net/articles/JsonPath/">JSONPath</a> expression specifying which items the <code>comparator</code> should be evaluated for.
+     * @param comparator    Comparator that should be applied for all items that match the <code>jsonPath</code> expression
+     */
+    public JSONPathCustomization(String jsonPath, ValueMatcher<Object> comparator) {
+        assert jsonPath != null;
+        assert comparator != null;
+        this.jsonPath = JsonPath.compile(jsonPath);
+        this.comparator = comparator;
+    }
+
+    /**
+     * Utility that constructs a generic customisation that will ignore all fields matching the JSONPath query.
+     * @param jsonPath  <a href="https://goessner.net/articles/JsonPath/">JSONPath</a>-query specifying which
+     *                  elements should get ignored
+     */
+    public static JSONPathCustomization ofIgnore(String jsonPath) {
+        return new JSONPathCustomization(jsonPath, IGNORE_FIELD);
+    }
+
+    public JsonPath getJsonPath() {
+        return jsonPath;
+    }
+
+    /**
+     * Return true if actual value matches expected value using this
+     * Customization's comparator. The equal method used for comparison depends
+     * on type of comparator.
+     * See: {@link Customization}; this is an exact copy.
+     *
+     * @param prefix
+     *            JSON path of the JSON item being tested (only used if
+     *            comparator is a LocationAwareValueMatcher)
+     * @param actual
+     *            JSON value being tested
+     * @param expected
+     *            expected JSON value
+     * @param result
+     *            JSONCompareResult to which match failure may be passed (only
+     *            used if comparator is a LocationAwareValueMatcher)
+     * @return true if expected and actual equal or any difference has already
+     *         been passed to specified result instance, false otherwise.
+     * @throws ValueMatcherException
+     *             if expected and actual values not equal and ValueMatcher
+     *             needs to override default comparison failure message that
+     *             would be generated if this method returned false.
+     */
+    public boolean matches(String prefix, Object actual, Object expected,
+                           JSONCompareResult result) throws ValueMatcherException {
+        return CustomizationEvaluator.matches(comparator, prefix, actual, expected, result);
+    }
+}

--- a/src/main/java/org/skyscreamer/jsonassert/comparator/JSONPathComparator.java
+++ b/src/main/java/org/skyscreamer/jsonassert/comparator/JSONPathComparator.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.skyscreamer.jsonassert.comparator;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.spi.json.JsonOrgJsonProvider;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.JSONCompareResult;
+import org.skyscreamer.jsonassert.JSONPathCustomization;
+import org.skyscreamer.jsonassert.ValueMatcherException;
+
+import java.util.*;
+
+/**
+ * Provides Custom matching support like {@link CustomComparator} but via <a href="https://goessner.net/articles/JsonPath/">JSONPath</a>
+ * <br><br>
+ * This class is thread-safe, but reusing instances of it would result in blocking against it.
+ * So <b>consider instantiating different instances of it per testcase</b> if running a multi-threaded/parallel test executor.
+ *
+ * @author Shane B. (<a href="mailto:shane@wander.dev">shane@wander.dev</a>)
+ */
+public class JSONPathComparator extends DefaultComparator {
+    private final Configuration jsonPathConfig;
+
+    private final Collection<JSONPathCustomization> customizations;
+
+    private final Map<JSONPathCustomization, Object> resultCache = new HashMap<>();
+
+    private JSONObject actual = null;
+
+    /**
+     * Create an instance of the JSONPath based comparator.
+     * <br>
+     * This is similar to {@link CustomComparator}, except that the path specification supports
+     * full <a href="https://goessner.net/articles/JsonPath/">JSONPath</a> via
+     * <a href="https://github.com/jayway/JsonPath">com.jayway.jsonpath:json-path</a>.
+     * <br>
+     * This means that {@link CustomComparator}'s more limited path specification is supported
+     * <b>and</b> full JSONPath queries are supported too.
+     * <br><br>
+     * If multiple {@link JSONPathCustomization} are specified that match the same JSON element,
+     * then all of them will be evaluated. If any of their comparators return <code>false</code> for the matching element,
+     * then the comparison will be considered as failed overall.
+     * <br><br>
+     * Refer to class {@link JSONPathCustomization} for examples.
+     *
+     * @param mode              Comparator mode
+     * @param customizations    Validation specification overrides for all nodes that match the specified JSONPath queries
+     */
+    public JSONPathComparator(JSONCompareMode mode, JSONPathCustomization... customizations) {
+        super(mode);
+        this.jsonPathConfig = new Configuration.ConfigurationBuilder()
+                .jsonProvider(new JsonOrgJsonProvider()).build();
+
+        this.customizations = Arrays.asList(customizations);
+    }
+
+    @Override
+    public synchronized void compareJSON(String prefix, JSONObject expected, JSONObject actual, JSONCompareResult result) {
+        // synchronised to make reuse of a comparator technically possible.
+        // Main reason to capture and set the member here rather than in the constructor is
+        // to not hugely change the implementation details of JSONAssert, while still maintaining
+        // the necessary pointers to the top level of the JSONObject hierarchy.
+        // This means that in a multithreaded environment we will block on this method.
+        // So: devs should ideally not reuse instances of this comparator across tests that are meant to run in parallel.
+        boolean isRootCall = this.actual == null;
+        if (isRootCall) {
+            this.actual = actual;
+            this.resultCache.clear();
+        }
+
+        super.compareJSON(prefix, expected, actual, result);
+
+        if (isRootCall) {
+            this.actual = null;
+        }
+    }
+
+    @Override
+    public void compareValues(String prefix, Object expectedValue, Object actualValue, JSONCompareResult result) {
+        // This is very similar to CustomComparator.
+        // In fact, I question why CustomComparator supports some level of wildcard matching,
+        // but only compares a *single* Customisation being evaluated.
+        // It appears quite possible have multiple Customisations with a matching path in it...
+        List<JSONPathCustomization> customizations = getCustomization(actualValue);
+        if (!customizations.isEmpty()) {
+            try {
+                // Does *any* of the customisations result in a test failure?
+                for (JSONPathCustomization customization : customizations) {
+                    if (!customization.matches(prefix, expectedValue, actualValue, result)) {
+                        result.fail(prefix, expectedValue, actualValue);
+                    }
+                }
+            } catch (ValueMatcherException e) {
+                result.fail(prefix, e);
+            }
+        } else {
+            super.compareValues(prefix, expectedValue, actualValue, result);
+        }
+    }
+
+    /**
+     * Some implementation details need to be known here:
+     * <br><br>
+     * {@link org.skyscreamer.jsonassert} uses the {@link org.json} implementation of JSON in Java,
+     * as does the {@link JsonOrgJsonProvider} for {@link com.jayway.jsonpath}.
+     * <br><br>
+     * Both libraries will ultimately recursively navigate the JSON tree of the parsed JSON objects.
+     * They will <b>reuse</b> the same instances (i.e. the same references/pointers) of the JSON objects
+     * in this tree, which is only parsed once (initially).
+     * <br>
+     * Furthermore, observe that in Java, due to
+     * <a href="https://docs.oracle.com/javase/tutorial/java/data/autoboxing.html">Primitive Boxing</a>,
+     * even primitive datatypes in the tree (<code>long</code>, <code>int</code>, ...) will actually
+     * be a pointer/reference.
+     * <br><br>
+     * Consequently, it is a completely valid strategy to evaluate a JSONPath expression against the JSON tree
+     * and find all results, and compare those against any node in the recursively navigated JSON tree
+     * by reference/pointer (i.e. <code>==</code>) to determine if they are the same object.
+     * <br><br>
+     * Here, we use this strategy to determine all the customisation rules applicable to a given JSON Tree node.
+     *
+     * @param actualValue The object to find all applicable {@link JSONPathCustomization}s for
+     * @return  Customisations applicable to this object
+     */
+    private List<JSONPathCustomization> getCustomization(Object actualValue) {
+        List<JSONPathCustomization> applicableCustomisations = new ArrayList<>();
+        for (JSONPathCustomization c : customizations) {
+            // some implementation details need to be known here.
+            // JSONAssert uses the org.json
+            Object results = this.getCachedResult(c);
+
+            if (results instanceof JSONArray) {
+                // multiple results for JSONPath expression
+                // (something like $.items[*] might return this)
+                for (Object o : (JSONArray) results) {
+                    if (o == actualValue) {
+                        applicableCustomisations.add(c);
+                    }
+                }
+            } else if (results == actualValue) {
+                applicableCustomisations.add(c);
+            }
+        }
+        return applicableCustomisations;
+    }
+
+    /**
+     * Avoids performing queries multiple times. The result will always be the same.
+     */
+    private Object getCachedResult(JSONPathCustomization c) {
+        if (this.resultCache.containsKey(c)) {
+            return this.resultCache.get(c);
+        }
+        Object result = c.getJsonPath().read(this.actual, this.jsonPathConfig);
+        this.resultCache.put(c, result);
+        return result;
+    }
+}

--- a/src/test/java/org/skyscreamer/jsonassert/CustomizationEvaluatorTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/CustomizationEvaluatorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.skyscreamer.jsonassert;
+
+import org.json.JSONArray;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the shared utility class {@link CustomizationEvaluator}
+ *
+ * @author Shane B. (<a href="mailto:shane@wander.dev">shane@wander.dev</a>)
+ */
+public class CustomizationEvaluatorTest {
+
+    @Test
+    public void testMatchesTrue() {
+        boolean result = CustomizationEvaluator.matches((a, b) -> true, "foo", "any", "any", new JSONCompareResult());
+        assertTrue(result);
+    }
+
+    @Test
+    public void testMatchesFalse() {
+        boolean result = CustomizationEvaluator.matches((a, b) -> false, "foo", "any", "any", new JSONCompareResult());
+        assertFalse(result);
+    }
+
+    @Test
+    public void testMatchesTrueLocationAware() {
+        JSONArray expected = new JSONArray();
+        expected.put("foo");
+        JSONArray actual = new JSONArray();
+        actual.put("foo");
+        JSONCompareResult result = new JSONCompareResult();
+        boolean returnedResult = CustomizationEvaluator.matches(
+                new ArrayValueMatcher<>(
+                        new CustomComparator(
+                                JSONCompareMode.LENIENT,
+                                new Customization("any[0]", (a, b) -> true)), 0, 1),
+                "any",
+                actual,
+                expected,
+                result
+        );
+        assertTrue(returnedResult);
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void testMatchesFalseLocationAware() {
+        JSONArray expected = new JSONArray();
+        expected.put("foo");
+        JSONArray actual = new JSONArray();
+        actual.put("foo");
+        JSONCompareResult result = new JSONCompareResult();
+        boolean returnedResult = CustomizationEvaluator.matches(
+                new ArrayValueMatcher<>(
+                        new CustomComparator(
+                                JSONCompareMode.LENIENT,
+                                new Customization("any[0]", (a, b) -> false)), 0, 1),
+                "any",
+                actual,
+                expected,
+                result
+        );
+        assertTrue(returnedResult);
+        assertTrue(result.getMessage(), result.failed());
+        assertEquals(1, result.getFieldFailures().size());
+        assertEquals("any[0]", result.getFieldFailures().get(0).getField());
+    }
+}

--- a/src/test/java/org/skyscreamer/jsonassert/JSONCompareJSONPathTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONCompareJSONPathTest.java
@@ -1,0 +1,455 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.skyscreamer.jsonassert;
+
+import com.jayway.jsonpath.*;
+import com.jayway.jsonpath.spi.json.JsonOrgJsonProvider;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.comparator.JSONPathComparator;
+
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+import static org.skyscreamer.jsonassert.JSONCompare.compareJSON;
+
+/**
+ * Tests for the {@link JSONPathComparator} comparator, at the JSON String level.
+ *
+ * @author Shane B. (<a href="mailto:shane@wander.dev">shane@wander.dev</a>)
+ */
+public class JSONCompareJSONPathTest {
+    private static final Configuration CONFIG = Configuration.builder()
+            .jsonProvider(new JsonOrgJsonProvider())
+            .build();
+
+    private static final Configuration CONFIG_NULLABLE_LEAVES = CONFIG.addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL);
+
+    final String bookStoreTemplate = "{\n" +
+            "    \"store\": {\n" +
+            "        \"book\": [\n" +
+            "            {\n" +
+            "                \"category\": \"reference\",\n" +
+            "                \"author\": \"Nigel Rees\",\n" +
+            "                \"title\": \"Sayings of the Century\",\n" +
+            "                \"price\": 8.95\n" +
+            "            },\n" +
+            "            {\n" +
+            "                \"category\": \"fiction\",\n" +
+            "                \"author\": \"Evelyn Waugh\",\n" +
+            "                \"title\": \"Sword of Honour\",\n" +
+            "                \"price\": 12.99\n" +
+            "            },\n" +
+            "            {\n" +
+            "                \"category\": \"fiction\",\n" +
+            "                \"author\": \"Herman Melville\",\n" +
+            "                \"title\": \"Moby Dick\",\n" +
+            "                \"isbn\": \"0-553-21311-3\",\n" +
+            "                \"price\": 8.99\n" +
+            "            },\n" +
+            "            {\n" +
+            "                \"category\": \"fiction\",\n" +
+            "                \"author\": \"J. R. R. Tolkien\",\n" +
+            "                \"title\": \"The Lord of the Rings\",\n" +
+            "                \"isbn\": \"0-395-19395-8\",\n" +
+            "                \"price\": 22.99\n" +
+            "            }\n" +
+            "        ],\n" +
+            "        \"bicycle\": {\n" +
+            "            \"color\": \"red\",\n" +
+            "            \"price\": 19.95\n" +
+            "        }\n" +
+            "    },\n" +
+            "    \"expensive\": 10\n" +
+            "}";
+
+    String jsonTemplateIdNesting = "{\n" +
+            "    \"id\": \"123456\",\n" +
+            "    \"other\": 1,\n" +
+            "    \"more\": [1, 2, 3],\n" +
+            "    \"evenMore\": {\n" +
+            "        \"nesting\": {\n" +
+            "            \"id\": \"123456\"\n" +
+            "        },\n" +
+            "        \"and\": \"then\",\n" +
+            "        \"more\": [\n" +
+            "            {\n" +
+            "                \"id\": \"123456\",\n" +
+            "                \"one\": \"foo\"\n" +
+            "            },\n" +
+            "            {\n" +
+            "                \"id\": \"123456\",\n" +
+            "                \"one\": \"bar\"\n" +
+            "            },\n" +
+            "            {\n" +
+            "                \"id\": \"123456\",\n" +
+            "                \"one\": \"baz\"\n" +
+            "            }\n" +
+            "        ]\n" +
+            "    }\n" +
+            "}";
+
+    String jsonTemplateMultipleValidations = "{\n" +
+            "    \"foo\": \"bar\",\n" +
+            "    \"items\": [\n" +
+            "        {\n" +
+            "            \"id\": 1,\n" +
+            "            \"timestamp\": 1742679828951\n" +
+            "        }, \n" +
+            "        {\n" +
+            "            \"id\": 2,\n" +
+            "            \"timestamp\": 1742679828952\n" +
+            "        },\n" +
+            "        {\n" +
+            "            \"id\": 3,\n" +
+            "            \"timestamp\": 1742679828953\n" +
+            "        }\n" +
+            "    ],\n" +
+            "    \"timestamp\": 1742679828954,\n" +
+            "    \"thisFieldWontMatchButShouldBeIgnored\": \"i don't match!\"\n" +
+            "}";
+
+    @Test
+    public void whenBasicSetup() {
+        DocumentContext expected = JsonPath.parse(bookStoreTemplate, CONFIG);
+        expected.set("$.expensive", 11);
+
+        JSONCompareResult result = compareJSON(
+                expected.jsonString(),
+                bookStoreTemplate,
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        new JSONPathCustomization("$.expensive", (expectedNode, actualNode) -> (int)actualNode == 10))
+        );
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenBasicQueryInArray() {
+        DocumentContext actual = JsonPath.parse(bookStoreTemplate, CONFIG);
+        actual.set("$.store.book[1].title", "override!");
+
+        JSONCompareResult result = compareJSON(
+                bookStoreTemplate,
+                actual.jsonString(),
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // this isn't jsonpath!
+                        new JSONPathCustomization("$.store.book[1].title", (expectedNode, actualNode) -> actualNode.equals("override!")))
+        );
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenInvalidQuery() {
+        DocumentContext actual = JsonPath.parse(bookStoreTemplate, CONFIG);
+        actual.set("$.store.book[1].title", "override!");
+
+        // I think throwing here makes sense?
+        assertThrows(PathNotFoundException.class, () -> compareJSON(
+                bookStoreTemplate,
+                actual.jsonString(),
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // this isn't jsonpath!
+                        new JSONPathCustomization("/store/book[1]/title", (expectedNode, actualNode) -> actualNode.equals("override!")))
+        ));
+    }
+
+    @Test
+    public void whenPathStartingWithout$Test() {
+        DocumentContext expected = JsonPath.parse(bookStoreTemplate, CONFIG);
+        expected.set("$.expensive", 11);
+
+        JSONCompareResult result = compareJSON(
+                expected.jsonString(),
+                bookStoreTemplate,
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        new JSONPathCustomization("expensive", (expectedNode, actualNode) -> (int)actualNode == 10))
+        );
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenPathStartingWithout$ArrayTest() {
+        DocumentContext actual = JsonPath.parse(bookStoreTemplate, CONFIG);
+        actual.set("$.store.book[1].title", "override!");
+
+        JSONCompareResult result = compareJSON(
+                bookStoreTemplate,
+                actual.jsonString(),
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // this isn't jsonpath!
+                        new JSONPathCustomization("store.book[1].title", (expectedNode, actualNode) -> actualNode.equals("override!")))
+        );
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenMultiFieldCustomValidationOverrideCase() {
+        DocumentContext expected = JsonPath.parse(jsonTemplateMultipleValidations, CONFIG);
+        // make it so that the template does not match anymore:
+        expected.set("$.items[*].timestamp", 0L);
+        expected.set("$.timestamp", 0L);
+        expected.set("$.thisFieldWontMatchButShouldBeIgnored", "ignoreMe");
+
+        JSONCompareResult result = compareJSON(
+                expected.jsonString(),
+                jsonTemplateMultipleValidations,
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // matches the nested timestamps inside of the array
+                        new JSONPathCustomization("$.**.timestamp", (expectedNode, actualNode) -> actualNode instanceof Long),
+                        // matches the timestamp at the root
+                        new JSONPathCustomization("$.timestamp", (expectedNode, actualNode) -> (Long) actualNode == 1742679828954L),
+                        // generic ignore
+                        JSONPathCustomization.ofIgnore("$.thisFieldWontMatchButShouldBeIgnored"))
+        );
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenHasNestedCustomValidation() {
+        DocumentContext expected = JsonPath.parse(jsonTemplateIdNesting, CONFIG);
+        expected.set("$..id", "0");
+
+        JSONCompareResult result = compareJSON(
+                expected.jsonString(),
+                jsonTemplateIdNesting,
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // all the id fields, which do not match in actual vs expected, are being overridden here:
+                        new JSONPathCustomization("$..id", (expectedNode, actualNode) -> actualNode.equals("123456")))
+        );
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenHasUuidsWithCustomUuidValidation() {
+        DocumentContext expected = JsonPath.parse(bookStoreTemplate, CONFIG_NULLABLE_LEAVES);
+        // add these fields to the template for the test
+        expected.set("$.store.book[*].uuid", "00000000-0000-0000-0000-000000000000");
+        expected.set("$.store.bicycle.uuid", "00000000-0000-0000-0000-000000000000");
+
+        // populate these fields with random ones for the test
+        DocumentContext actual = JsonPath.parse(bookStoreTemplate, CONFIG_NULLABLE_LEAVES);
+        for (int i = 0; i < 4; ++i) {
+            actual.set("$.store.book[" + i + "].uuid", UUID.randomUUID().toString());
+        }
+        actual.set("$.store.bicycle.uuid", UUID.randomUUID().toString());
+
+        JSONCompareResult result = compareJSON(
+                expected.jsonString(),
+                actual.jsonString(),
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // We ignore the field expensive at any level in the json IF the value of it is > 0 or exactly -1
+                        new JSONPathCustomization(
+                                "$..uuid",
+                                (expectedNode, actualNode) -> {
+                                    try {
+                                        UUID.fromString((String) actualNode); // try to parse as UUID
+                                        return true; // when parsing succeeds
+                                    } catch (IllegalArgumentException e) {
+                                        return false; // when parsing fails
+                                    }
+                                })
+        ));
+        // even though there was a UUID mismatch, this passes
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenHasUuidsWithCustomUuidValidationFailCase() {
+        DocumentContext expected = JsonPath.parse(bookStoreTemplate, CONFIG_NULLABLE_LEAVES);
+        // add these fields to the template for the test
+        expected.set("$.store.book[*].uuid", "00000000-0000-0000-0000-000000000000");
+        expected.set("$.store.bicycle.uuid", "00000000-0000-0000-0000-000000000000");
+
+        // populate these fields with random ones for the test
+        DocumentContext actual = JsonPath.parse(bookStoreTemplate, CONFIG_NULLABLE_LEAVES);
+        for (int i = 0; i < 4; ++i) {
+            actual.set("$.store.book[" + i + "].uuid", UUID.randomUUID().toString());
+        }
+        actual.set("$.store.bicycle.uuid", "not-valid-uuid");
+
+        JSONCompareResult result = compareJSON(
+                expected.jsonString(),
+                actual.jsonString(),
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // We ignore the field expensive at any level in the json IF the value of it is > 0 or exactly -1
+                        new JSONPathCustomization(
+                                "$..uuid",
+                                (expectedNode, actualNode) -> {
+                                    try {
+                                        UUID.fromString((String) actualNode); // try to parse as UUID
+                                        return true; // when parsing succeeds
+                                    } catch (IllegalArgumentException e) {
+                                        return false; // when parsing fails
+                                    }
+                                })
+                ));
+        // even though there was a UUID mismatch, this passes
+        assertTrue(result.getMessage(), result.failed());
+        assertEquals(1, result.getFieldFailures().size());
+        assertEquals("store.bicycle.uuid", result.getFieldFailures().get(0).getField());
+    }
+
+    @Test
+    public void whenJsonPathMatchesAutoboxedPrimitive() {
+        DocumentContext expected = JsonPath.parse(bookStoreTemplate, CONFIG);
+        expected.set("$.expensive", 0);
+
+        DocumentContext actual = JsonPath.parse(bookStoreTemplate, CONFIG);
+        actual.set("$.expensive", -1);
+
+        JSONCompareResult result = compareJSON(
+                expected.jsonString(),
+                actual.jsonString(),
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // We ignore the field expensive at any level in the json IF the value of it is > 0 or exactly -1
+                        new JSONPathCustomization(
+                                "$..expensive",
+                                (expectedNode, actualNode) -> (int)actualNode > 0 || (int)actualNode == -1))
+        );
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenJsonPathHasRegexQuery() {
+        DocumentContext expected = JsonPath.parse(bookStoreTemplate, CONFIG);
+        // consider this to be a kind of "placeholder value"
+        // (this would usually cause a mismatch!)
+        // (a more "real-world" example of something like this might be a UUID that is randomly populated)
+        expected.set("$.store.book[?(@.isbn)].isbn", "0-000-00000-0");
+
+        Set<String> allowedISBN = new HashSet<>();
+        allowedISBN.add("0-553-21311-3");
+        allowedISBN.add("0-395-19395-8");
+
+        JSONCompareResult result = compareJSON(
+                expected.jsonString(),
+                bookStoreTemplate,
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // for all the books with an isbn field,
+                        // customise to further manually verify that the isbn field must be in the allowed list
+                        new JSONPathCustomization(
+                                "$..book[?(@.isbn =~ /0-.*/)].isbn",
+                                (expectedNode, actualNode) -> allowedISBN.contains((String) actualNode)))
+        );
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenJsonPathHasRegexQueryFailCase() {
+        DocumentContext expected = JsonPath.parse(bookStoreTemplate, CONFIG);
+        // consider this to be a kind of "placeholder value"
+        // (this would usually cause a mismatch!)
+        // (a more "real-world" example of something like this might be a UUID that is randomly populated)
+        expected.set("$.store.book[?(@.isbn)].isbn", "0-000-00000-0");
+
+        Set<String> allowedISBN = new HashSet<>();
+        allowedISBN.add("0-553-21311-3");
+
+        JSONCompareResult result = compareJSON(
+                expected.jsonString(),
+                bookStoreTemplate,
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // for all the books with an isbn field,
+                        // customise to further manually verify that the isbn field must be in the allowed list
+                        new JSONPathCustomization(
+                                "$..book[?(@.isbn =~ /0-.*/)].isbn",
+                                (expectedNode, actualNode) -> allowedISBN.contains((String) actualNode)))
+        );
+        assertTrue(result.getMessage(), result.failed());
+        assertEquals(1, result.getFieldFailures().size());
+        assertEquals("store.book[3].isbn", result.getFieldFailures().get(0).getField());
+    }
+
+    @Test
+    public void whenJsonPathHasRegexQueryWithNoMatchesFailCase() {
+        DocumentContext expected = JsonPath.parse(bookStoreTemplate, CONFIG);
+        // consider this to be a kind of "placeholder value"
+        // (this would usually cause a mismatch!)
+        // (a more "real-world" example of something like this might be a UUID that is randomly populated)
+        expected.set("$.store.book[?(@.isbn)].isbn", "0-000-00000-0");
+
+        Set<String> allowedISBN = new HashSet<>();
+        allowedISBN.add("0-553-21311-3");
+        allowedISBN.add("0-395-19395-8");
+
+        JSONCompareResult result = compareJSON(
+                expected.jsonString(),
+                bookStoreTemplate,
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // for all the books with an isbn field,
+                        // customise to further manually verify that the isbn field must be in the allowed list
+                        // (there are no isbns that start with "1-"!)
+                        new JSONPathCustomization(
+                                "$..book[?(@.isbn =~ /1-.*/)].isbn",
+                                (expectedNode, actualNode) -> allowedISBN.contains((String) actualNode)))
+        );
+        assertTrue(result.getMessage(), result.failed());
+        assertEquals(2, result.getFieldFailures().size());
+        assertEquals("store.book[2].isbn", result.getFieldFailures().get(0).getField());
+        assertEquals("store.book[3].isbn", result.getFieldFailures().get(1).getField());
+    }
+
+    @Test
+    public void whenIgnoringOnlyNestedFieldsWithIdenticalNames() {
+        DocumentContext actual = JsonPath.parse(bookStoreTemplate, CONFIG);
+        actual.set("$.store.book[*].price", 0.0f);
+        actual.set("$.store.bicycle.price", 1.0f);
+
+        JSONCompareResult result = compareJSON(
+                bookStoreTemplate,
+                actual.jsonString(),
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // ignore the non-matching of the price of all the books, (but not that of the bicycle)
+                        JSONPathCustomization.ofIgnore("$.store.book..price"))
+        );
+        assertTrue(result.getMessage(), result.failed());
+        assertEquals(1, result.getFieldFailures().size());
+        assertEquals("store.bicycle.price", result.getFieldFailures().get(0).getField());
+    }
+
+    @Test
+    public void whenJsonPathHasMathThenMatchingWorks() {
+        DocumentContext actual = JsonPath.parse(bookStoreTemplate, CONFIG);
+        actual.set("$..price", 0.1f);
+
+        JSONCompareResult result = compareJSON(
+                bookStoreTemplate,
+                actual.jsonString(),
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // ignore all the prices that are <= 0.2
+                        JSONPathCustomization.ofIgnore("$.store.book[?(@.price <= 0.2)].price"))
+        );
+        assertTrue(result.getMessage(), result.failed());
+        assertEquals(1, result.getFieldFailures().size());
+        assertEquals("store.bicycle.price", result.getFieldFailures().get(0).getField());
+    }
+
+    @Test
+    public void whenJsonPathSelectsSubRangeThenMatchingWorks() {
+        DocumentContext actual = JsonPath.parse(bookStoreTemplate, CONFIG);
+        actual.set("$.store.book[0:2].author", "this should normally cause a mismatch");
+
+        JSONCompareResult result = compareJSON(
+                bookStoreTemplate,
+                actual.jsonString(),
+                new JSONPathComparator(JSONCompareMode.STRICT,
+                        // ignore authors 0 and 1, which would otherwise be a mismatch
+                        JSONPathCustomization.ofIgnore("$.store.book[0:2].author"))
+        );
+        assertTrue(result.getMessage(), result.passed());
+    }
+}

--- a/src/test/java/org/skyscreamer/jsonassert/JSONPathCustomizationTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/JSONPathCustomizationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.skyscreamer.jsonassert;
+
+import com.jayway.jsonpath.InvalidPathException;
+import org.json.JSONArray;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link JSONPathCustomization}s
+ *
+ * @author Shane B. (<a href="mailto:shane@wander.dev">shane@wander.dev</a>)
+ */
+public class JSONPathCustomizationTest {
+
+    @Test
+    public void testOfIgnore() {
+        JSONPathCustomization cust = JSONPathCustomization.ofIgnore("$.foo.bar");
+        assertNotNull(cust);
+        assertNotNull(cust.getJsonPath());
+        assertEquals("$['foo']['bar']", cust.getJsonPath().getPath());
+
+        JSONCompareResult res = new JSONCompareResult();
+        cust.matches("foo.bar", "any", "any", res);
+        assertTrue(res.getMessage(), res.passed());
+    }
+
+    @Test
+    public void testInvalidPath() {
+        assertThrows(InvalidPathException.class, () -> new JSONPathCustomization("     ", (a, b) -> true));
+    }
+
+    @Test
+    public void testGeneric() {
+        JSONPathCustomization cust = new JSONPathCustomization("$.foo.bar", (a, b) -> true);
+        assertNotNull(cust);
+        assertNotNull(cust.getJsonPath());
+        assertEquals("$['foo']['bar']", cust.getJsonPath().getPath());
+
+        JSONCompareResult res = new JSONCompareResult();
+        cust.matches("foo.bar", "any", "any", res);
+        assertTrue(res.getMessage(), res.passed());
+    }
+
+    @Test
+    public void testArrayValueMatcher() {
+        ArrayValueMatcher<Object> arrayValueMatcher = new ArrayValueMatcher<Object>(
+                new CustomComparator(JSONCompareMode.LENIENT, new Customization("foo.bar[0]", (expectedElement, actualElement) -> (int) actualElement == 1)), 0, 1);
+
+        JSONPathCustomization cust = new JSONPathCustomization(
+                "$.foo.bar",
+                arrayValueMatcher
+        );
+        assertNotNull(cust);
+        assertNotNull(cust.getJsonPath());
+        assertEquals("$['foo']['bar']", cust.getJsonPath().getPath());
+
+        JSONCompareResult res = new JSONCompareResult();
+        JSONArray expected = new JSONArray();
+        expected.put(1);
+        expected.put(2);
+
+        JSONArray actual = new JSONArray();
+        actual.put(1);
+        actual.put(2);
+
+        cust.matches("foo.bar", actual, expected, res);
+        assertTrue(res.getMessage(), res.passed());
+    }
+}

--- a/src/test/java/org/skyscreamer/jsonassert/comparator/ArraySizeComparatorTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/comparator/ArraySizeComparatorTest.java
@@ -137,5 +137,4 @@ public class ArraySizeComparatorTest {
 	public void succeedsWhenActualArrayContainsBetween2And6Elements() {
 		JSONAssert.assertEquals("{a:[2,6]}", "{a:[7, 8, 9]}", new ArraySizeComparator(JSONCompareMode.LENIENT));
 	}
-
 }

--- a/src/test/java/org/skyscreamer/jsonassert/comparator/JSONPathComparatorTest.java
+++ b/src/test/java/org/skyscreamer/jsonassert/comparator/JSONPathComparatorTest.java
@@ -1,0 +1,381 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.skyscreamer.jsonassert.comparator;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.JSONCompareResult;
+import org.skyscreamer.jsonassert.JSONPathCustomization;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link JSONPathCustomization} comparator, at {@link org.json.JSONObject} level
+ *
+ * @author Shane B. (<a href="mailto:shane@wander.dev">shane@wander.dev</a>)
+ */
+public class JSONPathComparatorTest {
+
+    @Test
+    public void whenNoCustomizations() {
+        JSONPathComparator comparator = new JSONPathComparator(JSONCompareMode.STRICT);
+
+        JSONObject expected = new JSONObject();
+        expected.put("foo", "bar");
+        JSONArray expectedArray = new JSONArray();
+        expectedArray.put(1);
+        expectedArray.put(2);
+        expected.put("array", expectedArray);
+
+        JSONObject actual = new JSONObject();
+        actual.put("foo", "bar");
+        JSONArray actualArray = new JSONArray();
+        actualArray.put(1);
+        actualArray.put(2);
+        actual.put("array", actualArray);
+
+        JSONCompareResult result = new JSONCompareResult();
+
+        comparator.compareJSON("", expected, actual, result);
+
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenLenientAndNoCustomizations() {
+        JSONPathComparator comparator = new JSONPathComparator(JSONCompareMode.LENIENT);
+
+        JSONObject expected = new JSONObject();
+        expected.put("foo", "bar");
+        JSONArray expectedArray = new JSONArray();
+        expectedArray.put(1);
+        expectedArray.put(2);
+        expected.put("array", expectedArray);
+
+        JSONObject actual = new JSONObject();
+        actual.put("foo", "bar");
+        actual.put("baz", "bax");
+        JSONArray actualArray = new JSONArray();
+        actualArray.put(2);
+        actualArray.put(1);
+        actual.put("array", actualArray);
+
+        JSONCompareResult result = new JSONCompareResult();
+
+        comparator.compareJSON("", expected, actual, result);
+
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenNonExtensibleAndNoCustomizations() {
+        JSONPathComparator comparator = new JSONPathComparator(JSONCompareMode.NON_EXTENSIBLE);
+
+        JSONObject expected = new JSONObject();
+        expected.put("foo", "bar");
+        JSONArray expectedArray = new JSONArray();
+        expectedArray.put(1);
+        expectedArray.put(2);
+        expected.put("array", expectedArray);
+
+        JSONObject actual = new JSONObject();
+        actual.put("foo", "bar");
+        actual.put("baz", "bax");
+        JSONArray actualArray = new JSONArray();
+        actualArray.put(2);
+        actualArray.put(1);
+        actual.put("array", actualArray);
+
+        JSONCompareResult result = new JSONCompareResult();
+
+        comparator.compareJSON("", expected, actual, result);
+
+        assertTrue(result.getMessage(), result.failed());
+        assertEquals(1, result.getFieldUnexpected().size());
+        assertEquals("", result.getFieldUnexpected().get(0).getField());
+        assertEquals("baz", result.getFieldUnexpected().get(0).getActual());
+    }
+
+    @Test
+    public void whenStrictOrderAndNoCustomizations() {
+        JSONPathComparator comparator = new JSONPathComparator(JSONCompareMode.STRICT_ORDER);
+
+        JSONObject expected = new JSONObject();
+        expected.put("foo", "bar");
+        JSONArray expectedArray = new JSONArray();
+        expectedArray.put(1);
+        expectedArray.put(2);
+        expected.put("array", expectedArray);
+
+        JSONObject actual = new JSONObject();
+        actual.put("foo", "bar");
+        actual.put("baz", "bax");
+        JSONArray actualArray = new JSONArray();
+        actualArray.put(2);
+        actualArray.put(1);
+        actual.put("array", actualArray);
+
+        JSONCompareResult result = new JSONCompareResult();
+
+        comparator.compareJSON("", expected, actual, result);
+
+        assertTrue(result.getMessage(), result.failed());
+        assertEquals(2, result.getFieldFailures().size());
+        assertEquals("array[0]", result.getFieldFailures().get(0).getField());
+        assertEquals("array[1]", result.getFieldFailures().get(1).getField());
+    }
+
+    @Test
+    public void whenStrictAndExcludeMismatch() {
+        JSONPathComparator comparator = new JSONPathComparator(
+                JSONCompareMode.STRICT,
+                new JSONPathCustomization("$.baz", (expectedNode, actualNode) -> actualNode.equals("not expected!"))
+        );
+
+        JSONObject expected = new JSONObject();
+        expected.put("foo", "bar");
+        expected.put("baz", "expected!");
+        JSONArray expectedArray = new JSONArray();
+        expectedArray.put(1);
+        expectedArray.put(2);
+        expected.put("array", expectedArray);
+
+        JSONObject actual = new JSONObject();
+        actual.put("foo", "bar");
+        actual.put("baz", "not expected!");
+        JSONArray actualArray = new JSONArray();
+        actualArray.put(1);
+        actualArray.put(2);
+        actual.put("array", actualArray);
+
+        JSONCompareResult result = new JSONCompareResult();
+
+        comparator.compareJSON("", expected, actual, result);
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenStrictAndOnMismatch() {
+        JSONPathComparator comparator = new JSONPathComparator(
+                JSONCompareMode.STRICT,
+                new JSONPathCustomization("$.foo", (expectedNode, actualNode) -> true)
+        );
+
+        JSONObject expected = new JSONObject();
+        expected.put("foo", "bar");
+        expected.put("baz", "expected!");
+        JSONArray expectedArray = new JSONArray();
+        expectedArray.put(1);
+        expectedArray.put(2);
+        expected.put("array", expectedArray);
+
+        JSONObject actual = new JSONObject();
+        actual.put("foo", "bar");
+        actual.put("baz", "not expected!");
+        JSONArray actualArray = new JSONArray();
+        actualArray.put(1);
+        actualArray.put(2);
+        actual.put("array", actualArray);
+
+        JSONCompareResult result = new JSONCompareResult();
+
+        comparator.compareJSON("", expected, actual, result);
+        assertTrue(result.getMessage(), result.failed());
+        assertEquals(1, result.getFieldFailures().size());
+        assertEquals("baz", result.getFieldFailures().get(0).getField());
+    }
+
+    @Test
+    public void whenStrictAndExcludeArrayMismatch() {
+        JSONPathComparator comparator = new JSONPathComparator(
+                JSONCompareMode.STRICT,
+                new JSONPathCustomization("$.array[*]", (expectedNode, actualNode) -> true)
+        );
+
+        JSONObject expected = new JSONObject();
+        expected.put("foo", "bar");
+        JSONArray expectedArray = new JSONArray();
+        expectedArray.put(1);
+        expectedArray.put(2);
+        expected.put("array", expectedArray);
+
+        JSONObject actual = new JSONObject();
+        actual.put("foo", "bar");
+        JSONArray actualArray = new JSONArray();
+        actualArray.put(4);
+        actualArray.put(5);
+        actual.put("array", actualArray);
+
+        JSONCompareResult result = new JSONCompareResult();
+
+        comparator.compareJSON("", expected, actual, result);
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenStrictAndFailureDueToOneItemInArrayMismatch() {
+        JSONPathComparator comparator = new JSONPathComparator(
+                JSONCompareMode.STRICT,
+                new JSONPathCustomization("$.array[0:2]", (expectedNode, actualNode) -> true)
+        );
+
+        JSONObject expected = new JSONObject();
+        expected.put("foo", "bar");
+        JSONArray expectedArray = new JSONArray();
+        expectedArray.put(1);
+        expectedArray.put(2);
+        expectedArray.put(3);
+        expected.put("array", expectedArray);
+
+        JSONObject actual = new JSONObject();
+        actual.put("foo", "bar");
+        JSONArray actualArray = new JSONArray();
+        actualArray.put(1);
+        actualArray.put(2);
+        actualArray.put(99999);
+        actual.put("array", actualArray);
+
+        JSONCompareResult result = new JSONCompareResult();
+
+        comparator.compareJSON("", expected, actual, result);
+        assertTrue(result.getMessage(), result.failed());
+        assertEquals(1, result.getFieldFailures().size());
+        assertEquals("array[2]", result.getFieldFailures().get(0).getField());
+    }
+
+    @Test
+    public void whenStrictAndFailureDueToInnerObjectMismatch() {
+        JSONPathComparator comparator = new JSONPathComparator(
+                JSONCompareMode.STRICT,
+                new JSONPathCustomization("$.foo", (expectedNode, actualNode) -> true)
+        );
+
+        JSONObject expected = new JSONObject();
+        expected.put("foo", "bar");
+        JSONObject expectedInner = new JSONObject();
+        expectedInner.put("foo", "bar");
+        expected.put("inner", expectedInner);
+
+
+        JSONObject actual = new JSONObject();
+        actual.put("foo", "bar");
+        JSONObject actualInner = new JSONObject();
+        actualInner.put("foo", "mismatch!");
+        actual.put("inner", actualInner);
+
+        JSONCompareResult result = new JSONCompareResult();
+
+        comparator.compareJSON("", expected, actual, result);
+        assertTrue(result.getMessage(), result.failed());
+        assertEquals(1, result.getFieldFailures().size());
+        assertEquals("inner.foo", result.getFieldFailures().get(0).getField());
+    }
+
+    @Test
+    public void whenStrictAndIgnoreNestedMismatch() {
+        JSONPathComparator comparator = new JSONPathComparator(
+                JSONCompareMode.STRICT,
+                new JSONPathCustomization("$..inner", (expectedNode, actualNode) -> true)
+        );
+
+        JSONObject expected = new JSONObject();
+        expected.put("foo", "bar");
+        JSONObject expectedInner = new JSONObject();
+        expectedInner.put("foo", "bar");
+        expected.put("inner", expectedInner);
+
+
+        JSONObject actual = new JSONObject();
+        actual.put("foo", "bar");
+        JSONObject actualInner = new JSONObject();
+        actualInner.put("foo", "mismatch!");
+        actual.put("inner", actualInner);
+
+        JSONCompareResult result = new JSONCompareResult();
+
+        comparator.compareJSON("", expected, actual, result);
+        assertTrue(result.getMessage(), result.passed());
+    }
+
+    @Test
+    public void whenMultiThreading() {
+        // try to recreate a scenario where the inner cache/and inner
+        // this.actual reference might get screwed up
+        // (ideally test writers should use separate instances of JSONPathComparator
+        // to not block on it in their tests)
+        JSONPathComparator comparator = new JSONPathComparator(
+                JSONCompareMode.STRICT,
+                new JSONPathCustomization("$.foo", (expectedNode, actualNode) -> actualNode.equals("bar")),
+                new JSONPathCustomization("$.inner.baz", (expectedNode, actualNode) -> actualNode.equals("match!"))
+        );
+
+        final JSONObject expected = new JSONObject();
+        expected.put("foo", "bar");
+        JSONObject expectedInner = new JSONObject();
+        expectedInner.put("baz", "match!");
+        expected.put("inner", expectedInner);
+
+        List<MultithreadedTestCase> tests = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            if (i % 2 == 0) {
+                tests.add(new MultithreadedTestCase("match!", false));
+            } else {
+                tests.add(new MultithreadedTestCase("mismatch!", true));
+            }
+        }
+
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CompletableFuture[] tasks = tests.stream().map(testRun ->
+                CompletableFuture.runAsync(() -> {
+
+                    JSONObject actual = new JSONObject();
+                    actual.put("foo", "bar");
+                    JSONObject actualInner = new JSONObject();
+                    actualInner.put("baz", testRun.innerBaz);
+                    actual.put("inner", actualInner);
+
+                    JSONCompareResult result = new JSONCompareResult();
+
+                    // this should be thread-safe
+                    comparator.compareJSON("", expected, actual, result);
+
+                    assertEquals(result.getMessage(), result.failed(), testRun.shouldFail);
+                }, executorService)
+        ).toArray(CompletableFuture[]::new);
+
+        CompletableFuture.allOf(tasks).join();
+        // all the assertEquals above should succeed!
+        executorService.shutdown();
+    }
+
+    private static class MultithreadedTestCase {
+        private final String innerBaz;
+        private final boolean shouldFail;
+
+        private MultithreadedTestCase(String innerBaz, boolean shouldFail) {
+            this.innerBaz = innerBaz;
+            this.shouldFail = shouldFail;
+        }
+    }
+}


### PR DESCRIPTION
Hi,

So first of all, thank you for the good work with this library! 

It has saved us a lot of time with regards to writing a bunch of crappy chained `getX`😄 

## Context

I work on a project where we use this library to validate a bunch of large JSON Objects. Because of these (frankly excessively large and complex) JSON objects, we typically store some large testcase JSON in our test `resources` folder, and then dynamically manipulate it using [json-path/JsonPath](https://github.com/json-path/JsonPath) to create certain scenarios (e.g. field randomly missing). The reason for doing this is similar to your reason for creating this library -- reducing a bunch of annoying `getX`/`setX` chains. 

This kind of setup looks like this:

```java

DocumentContext doc = JsonPath.parse(getStringContent("resources/testInput1.json"));
// most standard stuff:
doc.set("$.some.very.very[0].nested.field", 1234567);
doc.delete("$.yet.another.field[*].that.is.nested");
doc.set("$..itemId", UUID.randomUUID()); 


String jsonResult = doSomethingWithTheJson(doc.jsonString());

JSONAssert.assertEquals(
   getStringContent("resources/testOutput1.json"),
   jsonResult,
  // customisations
);
```

Observe at the bottom we will frequently try to add customisation rules for similar reasons to the input manipulation. For example, we sometimes want to ignore things about some fields, e.g.:
- a dynamically generated `timestamp unix epoch (long)`, where we want the timestamp to maybe just be later than some time but not match a specific value)
- a dynamically generated `UUID (string)`, where we just want to be sure the field is a string in the UUID pattern.

We have noted that while it seems that some level of "JSONPath" is supported via wildcards, it doesn't match in a lot of ways that we would have expected, e.g. the type of query like `$..itemId` in my snippet above is not supported.

And especially [complex conditional JSONpath queries as in this section of the Jayway JsonPath project's readme](https://github.com/json-path/JsonPath?tab=readme-ov-file#path-examples) are not supported.

## Solution / Proposal

As I noted that this library uses the `org.json` json implementation, which is one of the one supported by `com.jayway.jsonpath` (the [most popular JSONPath implementation](https://github.com/json-path/JsonPath) that we use in our setup and that I included in the snippet above), I figured it is quite simple to implement support here for full JSONPath, and hence I went ahead and created this MR to add this support.

The Unit Test Cases and JavaDocs should provide some details about my idea/implementation.

I was wondering what everybody's thoughts are on adding support for this? This would address request #15  which I see is relatively popular

----------

Sidenote: I would also propose looking into whether [built-in support can be added for these customisations by IntelliJ Idea via Built-in Language Injections](https://www.jetbrains.com/help/idea/language-injections-settings.html) like exists for the Jaway JsonPath library. 

This is quite useful and I see they already had an entry for the JSONAssert json strings to be JSON5:

![image](https://github.com/user-attachments/assets/c361e8eb-8a4c-4d08-9a6e-9f8a89b154c9)
